### PR TITLE
Add User and UserCredentials Complete Domain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,34 +29,44 @@
     <properties>
         <java.version>17</java.version>
     </properties>
+
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-h2console</artifactId>
-        </dependency>
+        <!-- JPA -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+
+        <!-- Validation -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+
+        <!-- Web -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
+        <!-- H2 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-h2console</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
         </dependency>
+
+        <!-- BCrypt (for hashing, no full security) -->
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
         </dependency>
+
+        <!-- Tests -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa-test</artifactId>

--- a/src/main/java/edu/arizona/videoshare/DataLoader.java
+++ b/src/main/java/edu/arizona/videoshare/DataLoader.java
@@ -1,8 +1,56 @@
 package edu.arizona.videoshare;
 
-import org.springframework.context.annotation.Configuration;
+import edu.arizona.videoshare.dto.user.UserRequest;
+import edu.arizona.videoshare.repository.UserRepository;
+import edu.arizona.videoshare.service.UserService;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Profile;
 
-@Configuration
-public class DataLoader {
+/**
+ * DataLoader
+ *
+ * Seeds initial data into the database when the application starts.
+ *
+ * Profile restriction:
+ * Disabled when the "test" profile is active to prevent interference with automated tests.
+ */
+@Profile("!test")
+@Component
+public class DataLoader implements CommandLineRunner {
 
+    private final UserService userService;
+    private final UserRepository userRepository;
+
+    public DataLoader(UserService userService, UserRepository userRepository) {
+        this.userService = userService;
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * Runs automatically at application startup.
+     * Seeds users only if the database is empty to prevent duplicate insertions.
+     */
+    @Override
+    public void run(String... args) {
+        // Avoid reseeding on restart
+        if (userRepository.count() > 0) return;
+
+        seed("ian", "idiazvachier@arizona.edu", "Ian Diaz-Vachier", "Password@123");
+        seed("user1", "user1@ua.edu", "TheUser1", "User1@123");
+    }
+
+    /**
+     * Helper method to seed a user via service layer.
+     */
+    private void seed(String username, String email, String displayName, String password) {
+        UserRequest req = new UserRequest();
+        req.username = username;
+        req.email = email;
+        req.displayName = displayName;
+        req.password = password;
+
+        // Uses service.register() to enforce rules
+        userService.register(req);
+    }
 }

--- a/src/main/java/edu/arizona/videoshare/config/SecurityBeans.java
+++ b/src/main/java/edu/arizona/videoshare/config/SecurityBeans.java
@@ -1,0 +1,24 @@
+package edu.arizona.videoshare.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+/**
+ * SecurityBeans Configuration
+ *
+ * Defines security-related infrastructure beans.
+ * Provides BCryptPasswordEncoder for password hashing
+ */
+@Configuration
+public class SecurityBeans {
+
+    /**
+     * BCrypt password encoder bean.
+     * Injected into UserService for secure password storage.
+     */
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/edu/arizona/videoshare/controller/UserController.java
+++ b/src/main/java/edu/arizona/videoshare/controller/UserController.java
@@ -1,4 +1,87 @@
 package edu.arizona.videoshare.controller;
 
+import edu.arizona.videoshare.dto.user.UserRequest;
+import edu.arizona.videoshare.dto.user.UserResponse;
+import edu.arizona.videoshare.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * UserController (Presentation Layer)
+ *
+ * Exposes REST endpoints for managing User resources.
+ * Base path: /api/users
+ */
+@RestController
+@RequestMapping("/api/users")
 public class UserController {
+
+    private final UserService service;
+
+    public UserController(UserService service) {
+        this.service = service;
+    }
+
+    /**
+     * POST /api/users
+     * Registers a new user.
+     * HTTP 201 Created on success.
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserResponse register(
+            @Valid @RequestBody UserRequest req) {
+        return UserResponse.of(service.register(req));
+    }
+
+    /**
+     * GET /api/users
+     * Returns all users. List of DTOs.
+     */
+    @GetMapping
+    public List<UserResponse> getAll() {
+        return service.getAll()
+                .stream()
+                .map(UserResponse::of)
+                .toList();
+    }
+
+    /**
+     * GET /api/users/{id}
+     * Returns a single user by id.
+     * Mapped globally to HTTP 404
+     */
+    @GetMapping("/{id}")
+    public UserResponse getById(
+            @PathVariable Long id) {
+        return UserResponse.of(service.getById(id));
+    }
+
+    /**
+     * PUT /api/users/{id}
+     * Updates profile fields for a user.
+     * HTTP 200 OK on success.
+     */
+    @PutMapping("/{id}")
+    public UserResponse update(
+            @PathVariable Long id,
+            @Valid @RequestBody UserRequest req
+    ) {
+        return UserResponse.of(service.update(id, req));
+    }
+
+    /**
+     * DELETE /api/users/{id}
+     * Deletes a user and cascades removal of associated credentials.
+     * HTTP 204 No Content on success.
+     */
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(
+            @PathVariable Long id) {
+        service.delete(id);
+    }
 }

--- a/src/main/java/edu/arizona/videoshare/dto/user/UserRequest.java
+++ b/src/main/java/edu/arizona/videoshare/dto/user/UserRequest.java
@@ -1,4 +1,60 @@
 package edu.arizona.videoshare.dto.user;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * UserRequest DTO
+ *
+ * Represents incoming data for user registration and profile updates.
+ *
+ * Security note:
+ * Raw passwords are accepted here but never persisted directly.
+ * The service layer hashes passwords using BCrypt before storage.
+ */
 public class UserRequest {
+
+    /**
+     * Public unique identifier for the user.
+     */
+    @NotBlank
+    @Size(min = 3, max = 50)
+    public String username;
+
+    /**
+     * Account login identifier.
+     */
+    @NotBlank
+    @Email
+    @Size(max = 254)
+    public String email;
+
+    /**
+     * Display name shown publicly.
+     */
+    @NotBlank
+    @Size(max = 100)
+    public String displayName;
+
+    /**
+     * Optional profile description.
+     */
+    @Size(max = 500)
+    public String bio;
+
+    /**
+     * Optional path to avatar image.
+     */
+    @Size(max = 500)
+    public String avatarUrl;
+
+    /**
+     * Raw password only used during registration or password update.
+     * BCrypt only uses the first 72 bytes of input.
+     * Service layer is responsible for hashing before persistence.
+     */
+    @NotBlank
+    @Size(min = 8, max = 72) // BCrypt only uses first 72 bytes
+    public String password;
 }

--- a/src/main/java/edu/arizona/videoshare/dto/user/UserResponse.java
+++ b/src/main/java/edu/arizona/videoshare/dto/user/UserResponse.java
@@ -1,4 +1,69 @@
 package edu.arizona.videoshare.dto.user;
 
+import edu.arizona.videoshare.model.enums.UserRole;
+import edu.arizona.videoshare.model.enums.UserStatus;
+
+import java.time.LocalDateTime;
+
+/**
+ * UserResponse DTO
+ *
+ * Represents outward-facing user data returned by the API.
+ *
+ * Important:
+ * Does NOT include passwordHash or credential data.
+ * Only exposes profile + system metadata fields.
+ */
 public class UserResponse {
+    /**
+     * Database-generated primary key.
+     */
+    public Long id;
+
+    /**
+     * Public username (unique).
+     */
+    public String username;
+
+    /**
+     * Account email.
+     */
+    public String email;
+
+    /**
+     * Display name shown in UI.
+     */
+    public String displayName;
+
+    /**
+     * Account status (ACTIVE, SUSPENDED, DELETED)
+     */
+    public UserStatus status;
+
+    /**
+     * System role (VIEWER, CREATOR, MOD, ADMIN)
+     */
+    public UserRole role;
+
+    /**
+     * Audit timestamps.
+     */
+    public LocalDateTime createdAt;
+    public LocalDateTime updatedAt;
+
+    /**
+     * Maps a User entity to a response DTO.
+     */
+    public static UserResponse of(edu.arizona.videoshare.model.entity.User u) {
+        var r = new UserResponse();
+        r.id = u.getId();
+        r.username = u.getUsername();
+        r.email = u.getEmail();
+        r.displayName = u.getDisplayName();
+        r.status = u.getStatus();
+        r.role = u.getRole();
+        r.createdAt = u.getCreatedAt();
+        r.updatedAt = u.getUpdatedAt();
+        return r;
+    }
 }

--- a/src/main/java/edu/arizona/videoshare/exception/ConflictException.java
+++ b/src/main/java/edu/arizona/videoshare/exception/ConflictException.java
@@ -1,0 +1,7 @@
+package edu.arizona.videoshare.exception;
+
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/edu/arizona/videoshare/exception/GlobalExceptionHandler.java
+++ b/src/main/java/edu/arizona/videoshare/exception/GlobalExceptionHandler.java
@@ -1,4 +1,98 @@
 package edu.arizona.videoshare.exception;
 
+import edu.arizona.videoshare.exception.response.ApiError;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+/**
+ * GlobalExceptionHandler
+ *
+ * Centralized REST exception handling for the application.
+ */
+@RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    /**
+     * Handles validation failures triggered by @Valid on request bodies.
+     * Returns HTTP 400 with structured field-level violations.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException ex) {
+        List<ApiError.FieldViolation> violations = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(fe -> new ApiError.FieldViolation(fe.getField(), prettyMessage(fe)))
+                .toList();
+
+        ApiError body = new ApiError(
+                HttpStatus.BAD_REQUEST.value(),
+                "Bad Request",
+                "Validation failed",
+                violations
+        );
+        return ResponseEntity.badRequest().body(body);
+    }
+
+    /**
+     * Handles business-level conflict errors.
+     * Returns HTTP 409 Conflict.
+     */
+    @ExceptionHandler(ConflictException.class)
+    ResponseEntity<ApiError> handleConflict(ConflictException ex) {
+        ApiError body = new ApiError(
+                HttpStatus.CONFLICT.value(),
+                "Conflict",
+                ex.getMessage(),
+                List.of()
+        );
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+    }
+
+    /**
+     * Handles resource-not-found scenarios.
+     * Returns HTTP 404 Not Found.
+     */
+    @ExceptionHandler(NotFoundException.class)
+    ResponseEntity<ApiError> handleNotFound(NotFoundException ex) {
+        ApiError body = new ApiError(
+                HttpStatus.NOT_FOUND.value(),
+                "Not Found",
+                ex.getMessage(),
+                List.of()
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
+
+    /**
+     * Handles database integrity violations.
+     * Ensures consistent 409 Conflict responses.
+     */
+    // If a race condition slips past existsBy* checks, DB uniqueness still enforces it.
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    ResponseEntity<ApiError> handleDataIntegrity(DataIntegrityViolationException ex) {
+        ApiError body = new ApiError(
+                HttpStatus.CONFLICT.value(),
+                "Conflict",
+                "Unique constraint violation",
+                List.of()
+        );
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+    }
+
+    /**
+     * Formats validation error messages.
+     */
+    private String prettyMessage(FieldError fe) {
+        return fe.getDefaultMessage() != null
+                ? fe.getDefaultMessage()
+                : "Invalid value";
+    }
 }

--- a/src/main/java/edu/arizona/videoshare/exception/NotFoundException.java
+++ b/src/main/java/edu/arizona/videoshare/exception/NotFoundException.java
@@ -1,4 +1,13 @@
 package edu.arizona.videoshare.exception;
 
-public class NotFoundException {
+/**
+ * NotFoundException
+ *
+ * Thrown when a requested resource does not exist.
+ * Represent domain-level "resource not found" errors
+ */
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/edu/arizona/videoshare/exception/response/ApiError.java
+++ b/src/main/java/edu/arizona/videoshare/exception/response/ApiError.java
@@ -1,0 +1,53 @@
+package edu.arizona.videoshare.exception.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * ApiError
+ *
+ * Standardized error response object returned by the REST API.
+ * Provides consistent error structure across the application
+ */
+public class ApiError {
+    /**
+     * Time at which the error occurred.
+     */
+    public LocalDateTime timestamp = LocalDateTime.now();
+
+    /**
+     * HTTP status code.
+     */
+    public int status;
+
+    /**
+     * Short error description.
+     */
+    public String error;
+
+    /**
+     * Detailed message explaining the issue.
+     */
+    public String message;
+
+    /**
+     * Optional validation field errors.
+     * Used when request body validation fails.
+     */
+    public List<FieldViolation> violations;
+
+    public ApiError(int status, String error, String message, List<FieldViolation> violations) {
+        this.status = status;
+        this.error = error;
+        this.message = message;
+        this.violations = violations;
+    }
+
+    /**
+     * Represents a single field-level validation error.
+     *
+     * Example:
+     * { "field": "email", "message": "must not be blank" }
+     */
+    public record FieldViolation(String field, String message) {}
+}

--- a/src/main/java/edu/arizona/videoshare/model/User.java
+++ b/src/main/java/edu/arizona/videoshare/model/User.java
@@ -1,4 +1,0 @@
-package edu.arizona.videoshare.model;
-
-public class User {
-}

--- a/src/main/java/edu/arizona/videoshare/model/Video.java
+++ b/src/main/java/edu/arizona/videoshare/model/Video.java
@@ -1,4 +1,0 @@
-package edu.arizona.videoshare.model;
-
-public class Video {
-}

--- a/src/main/java/edu/arizona/videoshare/model/entity/User.java
+++ b/src/main/java/edu/arizona/videoshare/model/entity/User.java
@@ -1,0 +1,169 @@
+package edu.arizona.videoshare.model.entity;
+
+import edu.arizona.videoshare.model.enums.UserRole;
+import edu.arizona.videoshare.model.enums.UserStatus;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+
+
+/**
+ * User entity
+ *
+ * Represents a platform account profile (public).
+ *
+ * Authentication secrets are NOT stored here; these are in {@link UserCredentials}.
+ * This is to help keep user profile concerns separate from security concerns, reducing
+ * the chance of accidentally exposing credential data in REST responses.
+ */
+@Entity
+@Table(
+        name = "users",
+        uniqueConstraints = {
+                // Database-level enforcement of business rule: unique username and email
+                @UniqueConstraint(name = "uk_users_username", columnNames = "username"),
+                @UniqueConstraint(name = "uk_users_email", columnNames = "email")
+        }
+)
+
+public class User {
+
+    /**
+     * Surrogate primary key.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * Unique identifier for display/URLs.
+     */
+    @NotBlank
+    @Size(min = 3, max = 50)
+    @Column(nullable = false, length = 50)
+    private String username;
+
+    /**
+     * Unique identifier for account.
+     */
+    @NotBlank
+    @Email
+    @Size(max = 254)
+    @Column(nullable = false, length = 254)
+    private String email;
+
+    /**
+     * Display label shown in UI (not unique).
+     */
+    @NotBlank
+    @Size(max = 100)
+    @Column(nullable = false, length = 100)
+    private String displayName;
+
+    /**
+     * Account timestamps. createdAt is always set; updatedAt is nullable until first update.
+     */
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    /**
+     * Account status for moderation/availability.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserStatus status = UserStatus.ACTIVE;
+
+    /**
+     * Optional profile fields.
+     */
+    @Size(max = 500)
+    @Column(length = 500)
+    private String bio;
+
+    @Size(max = 500)
+    @Column(length = 500)
+    private String avatarUrl;
+
+    /**
+     * Platform role for authorization. USerRole.VIEWER is default.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserRole role = UserRole.VIEWER;
+
+    /**
+     * 1:1 relationship to credentials (authentication data).
+     * Business Rule: Each User should have exactly one UserCredentials record.
+     */
+    @OneToOne(
+            mappedBy = "user",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            optional = false,
+            fetch = FetchType.LAZY
+    )
+
+    private UserCredentials credentials;
+
+    public User() {}
+
+    /**
+     * Set creation timestamp automatically when the row is first inserted.
+     */
+    @PrePersist
+    void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    /**
+     * Set update timestamp automatically any time the row is updated.
+     */
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * Helper to keep both sides of the bi-directional 1:1 association consistent.
+     */
+    public void attachCredentials(UserCredentials creds) {
+        this.credentials = creds;
+        creds.setUser(this);
+    }
+
+    // ---- Getters / Setters ----
+
+    public Long getId() { return id; }
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+
+    public UserStatus getStatus() { return status; }
+    public void setStatus(UserStatus status) { this.status = status; }
+
+    public String getBio() { return bio; }
+    public void setBio(String bio) { this.bio = bio; }
+
+    public String getAvatarUrl() { return avatarUrl; }
+    public void setAvatarUrl(String avatarUrl) { this.avatarUrl = avatarUrl; }
+
+    public UserRole getRole() { return role; }
+    public void setRole(UserRole role) { this.role = role; }
+
+    public UserCredentials getCredentials() { return credentials; }
+}

--- a/src/main/java/edu/arizona/videoshare/model/entity/UserCredentials.java
+++ b/src/main/java/edu/arizona/videoshare/model/entity/UserCredentials.java
@@ -1,0 +1,105 @@
+package edu.arizona.videoshare.model.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+
+
+/**
+ * UserCredentials entity
+ *
+ * Represents security/authentication data/
+ *
+ * Stores authentication-related fields separately from {@link User} profile data.
+ * Shared Primary Key association (UserCredentials.id == User.id)
+ * Implemented with @MapsId to ensure the credentials row shares the same PK as its user.
+ */
+@Entity
+@Table(name = "user_credentials")
+public class UserCredentials {
+
+    /**
+     * Shared primary key: this value is inherited from the associated User.id.
+     */
+    @Id
+    private Long id;
+
+    /**
+     * Owning side of the 1:1 relationship.
+     */
+    @OneToOne(optional = false)
+    @MapsId
+    @JoinColumn(
+            name = "user_id",
+            foreignKey = @ForeignKey(
+                    name = "fk_credentials_user"
+            )
+    )
+    private User user;
+
+    /**
+     * Secure one-way hash of the user's password.
+     */
+    @NotBlank
+    @Size(min = 20, max = 100) // BCrypt hashes are typically 60 chars
+    @Column(nullable = false, length = 100)
+    private String passwordHash;
+
+    /**
+     * Timestamp of when the password was last set/updated.
+     */
+    private LocalDateTime passwordUpdatedAt;
+
+    /**
+     * Number of consecutive failed authentication attempts.
+     */
+    @Column(nullable = false)
+    private int failedLoginAttempts = 0;
+
+    /**
+     * Lock flag (or lock indicator). TO be combined with lockedUntil.
+     */
+    @Column(nullable = false)
+    private boolean locked = false;
+
+    /**
+     * Temporary lockout expiration time.
+     */
+    private LocalDateTime lockedUntil;
+
+    public UserCredentials() {}
+
+    /**
+     * Sets passwordUpdatedAt if the application didn't explicitly provide it.
+     */
+    @PrePersist
+    void onCreate() {
+        if (passwordUpdatedAt == null) {
+            passwordUpdatedAt = LocalDateTime.now();
+        }
+    }
+
+    // ---- Getters / Setters ----
+
+    public Long getId() { return id; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public String getPasswordHash() { return passwordHash; }
+    public void setPasswordHash(String passwordHash) { this.passwordHash = passwordHash; }
+
+    public LocalDateTime getPasswordUpdatedAt() { return passwordUpdatedAt; }
+    public void setPasswordUpdatedAt(LocalDateTime passwordUpdatedAt) { this.passwordUpdatedAt = passwordUpdatedAt; }
+
+    public int getFailedLoginAttempts() { return failedLoginAttempts; }
+    public void setFailedLoginAttempts(int failedLoginAttempts) { this.failedLoginAttempts = failedLoginAttempts; }
+
+    public boolean isLocked() { return locked; }
+    public void setLocked(boolean locked) { this.locked = locked; }
+
+    public LocalDateTime getLockedUntil() { return lockedUntil; }
+    public void setLockedUntil(LocalDateTime lockedUntil) { this.lockedUntil = lockedUntil; }
+}

--- a/src/main/java/edu/arizona/videoshare/model/entity/Video.java
+++ b/src/main/java/edu/arizona/videoshare/model/entity/Video.java
@@ -1,0 +1,4 @@
+package edu.arizona.videoshare.model.entity;
+
+public class Video {
+}

--- a/src/main/java/edu/arizona/videoshare/model/enums/UserRole.java
+++ b/src/main/java/edu/arizona/videoshare/model/enums/UserRole.java
@@ -1,0 +1,8 @@
+package edu.arizona.videoshare.model.enums;
+
+public enum UserRole {
+    VIEWER,
+    CREATOR,
+    MODERATOR,
+    ADMIN
+}

--- a/src/main/java/edu/arizona/videoshare/model/enums/UserStatus.java
+++ b/src/main/java/edu/arizona/videoshare/model/enums/UserStatus.java
@@ -1,0 +1,7 @@
+package edu.arizona.videoshare.model.enums;
+
+public enum UserStatus {
+    ACTIVE,
+    SUSPENDED,
+    DELETED
+}

--- a/src/main/java/edu/arizona/videoshare/repository/UserCredentialsRepository.java
+++ b/src/main/java/edu/arizona/videoshare/repository/UserCredentialsRepository.java
@@ -1,0 +1,12 @@
+package edu.arizona.videoshare.repository;
+
+import edu.arizona.videoshare.model.entity.UserCredentials;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * UserCredentialsRepository
+ *
+ * Persistence abstraction for UserCredentials entities.
+ */
+public interface UserCredentialsRepository extends JpaRepository<UserCredentials, Long> {
+}

--- a/src/main/java/edu/arizona/videoshare/repository/UserRepository.java
+++ b/src/main/java/edu/arizona/videoshare/repository/UserRepository.java
@@ -1,4 +1,25 @@
 package edu.arizona.videoshare.repository;
 
-public class UserRepository {
+import edu.arizona.videoshare.model.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * UserRepository
+ *
+ * Persistence layer abstraction for User entities.
+ *
+ */
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    // Retrieves a User by email (login identifier)
+    Optional<User> findByEmail(String email);
+    // Retrieves a User by username (public identifier)
+    Optional<User> findByUsername(String username);
+
+    // Checks existence by email
+    boolean existsByEmail(String email);
+    // Checks existence by username.
+    boolean existsByUsername(String username);
 }

--- a/src/main/java/edu/arizona/videoshare/service/UserService.java
+++ b/src/main/java/edu/arizona/videoshare/service/UserService.java
@@ -1,4 +1,108 @@
 package edu.arizona.videoshare.service;
 
+import edu.arizona.videoshare.dto.user.UserRequest;
+import edu.arizona.videoshare.exception.ConflictException;
+import edu.arizona.videoshare.exception.NotFoundException;
+import edu.arizona.videoshare.model.entity.User;
+import edu.arizona.videoshare.model.entity.UserCredentials;
+import edu.arizona.videoshare.repository.UserRepository;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * UserService (Business Layer)
+ *
+ * This class implements business use-cases around User accounts.
+ *
+ */
+@Service
 public class UserService {
+
+    private final UserRepository users;
+    private final BCryptPasswordEncoder encoder;
+
+    public UserService(UserRepository users, BCryptPasswordEncoder encoder) {
+        this.users = users;
+        this.encoder = encoder;
+    }
+
+    /**
+     * CREATE: Registers a new user account.
+     */
+    @Transactional
+    public User register(UserRequest req) {
+
+        // Business rule: username/email unique
+        if (users.existsByUsername(req.username)) {
+            throw new ConflictException("Username already exists");
+        }
+        if (users.existsByEmail(req.email)) {
+            throw new ConflictException("Email already exists");
+        }
+
+        // Create user profile
+        User u = new User();
+        u.setUsername(req.username.trim());
+        u.setEmail(req.email.trim().toLowerCase());
+        u.setDisplayName(req.displayName.trim());
+
+        // Create credentials
+        // Because UserCredentials uses @MapsId, credentials will share the same PK as the user.
+        UserCredentials creds = new UserCredentials();
+        creds.setPasswordHash(encoder.encode(req.password));
+
+        // attachCredentials keeps both sides of the 1:1 mapping consistent in memory
+        u.attachCredentials(creds);
+
+        // Saving user cascades creds due to cascade=ALL on User.credentials
+        return users.save(u);
+    }
+
+    /**
+     * READ: Returns all users.
+     */
+    @Transactional(readOnly = true)
+    public List<User> getAll() {
+        return users.findAll();
+    }
+
+    /**
+     * READ: Returns a user by id.
+     */
+    @Transactional(readOnly = true)
+    public User getById(Long id) {
+        return users.findById(id)
+                .orElseThrow(() -> new NotFoundException("User not found: " + id));
+    }
+
+    /**
+     * UPDATE: Updates mutable profile fields for a user.
+     */
+    @Transactional
+    public User update(Long id, UserRequest req) {
+        User user = users.findById(id)
+                .orElseThrow(() -> new NotFoundException("User not found: " + id));
+
+        // Only update fields present in the request
+        if (req.displayName != null) user.setDisplayName(req.displayName.trim());
+        if (req.bio != null) user.setBio(req.bio.trim());
+        if (req.avatarUrl != null) user.setAvatarUrl(req.avatarUrl.trim());
+
+        return users.save(user);
+    }
+
+    /**
+     * DELETE: Deletes a user by id.
+     */
+    @Transactional
+    public void delete(Long id) {
+        if (!users.existsById(id)) {
+            throw new NotFoundException("User not found: " + id);
+        }
+        users.deleteById(id);
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,13 @@
 spring.application.name=video-share
 
-spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.url=jdbc:h2:mem:videoshare;DB_CLOSE_DELAY=-1
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
 
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console

--- a/src/test/java/edu/arizona/videoshare/repository/UserJpaTest.java
+++ b/src/test/java/edu/arizona/videoshare/repository/UserJpaTest.java
@@ -1,0 +1,122 @@
+package edu.arizona.videoshare.repository;
+
+import edu.arizona.videoshare.model.entity.User;
+import edu.arizona.videoshare.model.entity.UserCredentials;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * UserJpaTest
+ *
+ * Repository/ORM-focused tests using @DataJpaTest.
+ */
+@ActiveProfiles("test")
+@DataJpaTest
+class UserJpaTest {
+
+    @Autowired UserRepository userRepository;
+    @Autowired UserCredentialsRepository credsRepository;
+
+    /**
+     * Helper builder for creating a valid User + UserCredentials pair.
+     */
+    private User buildUser(String username, String email) {
+        User u = new User();
+        u.setUsername(username);
+        u.setEmail(email);
+        u.setDisplayName("TestUser");
+
+        UserCredentials c = new UserCredentials();
+
+        // Dummy bcrypt-looking string
+        c.setPasswordHash("$2a$10$dummyDummyDummyDummyDummyDummyDummyDummyDummyDummy");
+
+        u.attachCredentials(c);
+        return u;
+    }
+
+    /**
+     * Validates shared primary key mapping.
+     */
+    @Test
+    void savesUserAndCredentialsTogether_sharedPrimaryKey() {
+        User saved = userRepository.save(buildUser("ian2", "ian2@ua.edu"));
+
+        // user exists
+        assertNotNull(saved.getId());
+
+        // credentials exists and uses same id (shared PK)
+        UserCredentials creds = credsRepository.findById(saved.getId()).orElseThrow();
+        assertEquals(saved.getId(), creds.getId());
+        assertEquals(saved.getId(), creds.getUser().getId());
+    }
+
+    /**
+     * Validates lifecycle callback behavior.
+     */
+    @Test
+    void updatePersistsChanges_andSetsUpdatedAt() {
+        User u = userRepository.saveAndFlush(buildUser("ian4", "ian4@ua.edu"));
+
+        assertNull(u.getUpdatedAt()); // should be null right after create
+
+        u.setDisplayName("Updated Name");
+        User updated = userRepository.saveAndFlush(u);
+
+        assertEquals("Updated Name", updated.getDisplayName());
+        assertNotNull(updated.getUpdatedAt()); // @PreUpdate should have fired
+
+        // prove it’s persisted (fresh read)
+        User reloaded = userRepository.findById(u.getId()).orElseThrow();
+        assertEquals("Updated Name", reloaded.getDisplayName());
+        assertNotNull(reloaded.getUpdatedAt());
+    }
+
+    /**
+     * Validates cascade/orphan removal:
+     */
+    @Test
+    void deletingUserDeletesCredentials() {
+        User u = userRepository.saveAndFlush(buildUser("ian3", "ian3@ua.edu"));
+
+        userRepository.delete(u);
+        userRepository.flush();
+
+        assertFalse(credsRepository.findById(u.getId()).isPresent());
+    }
+
+    /**
+     * Validates DB-level unique constraint enforcement for username.
+     */
+    @Test
+    void usernameMustBeUnique_dbConstraint() {
+        userRepository.save(buildUser("user1", "user1@gmail.com"));
+
+        // second user with same username should violate unique constraint
+        User u2 = buildUser("user1", "user2@gmail.com");
+
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            userRepository.saveAndFlush(u2); // flush forces DB constraint check
+        });
+    }
+
+    /**
+     * Validates DB-level unique constraint enforcement for email.
+     */
+    @Test
+    void emailMustBeUnique_dbConstraint() {
+        userRepository.save(buildUser("user1", "user1@gmail.com"));
+
+        User u2 = buildUser("user2", "user1@gmail.com");
+
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            userRepository.saveAndFlush(u2);
+        });
+    }
+
+}

--- a/src/test/java/edu/arizona/videoshare/service/UserServiceTest.java
+++ b/src/test/java/edu/arizona/videoshare/service/UserServiceTest.java
@@ -1,0 +1,174 @@
+package edu.arizona.videoshare.service;
+
+import edu.arizona.videoshare.dto.user.UserRequest;
+import edu.arizona.videoshare.exception.ConflictException;
+import edu.arizona.videoshare.model.entity.User;
+import edu.arizona.videoshare.repository.UserCredentialsRepository;
+import edu.arizona.videoshare.repository.UserRepository;
+import edu.arizona.videoshare.exception.NotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * UserServiceTest
+ *
+ * Integration-style tests that run with Spring Boot and real repositories.
+ */
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class UserServiceTest {
+
+    @Autowired UserService userService;
+    @Autowired UserRepository userRepository;
+    @Autowired UserCredentialsRepository credsRepository;
+    @Autowired BCryptPasswordEncoder encoder;
+
+    /**
+     * Helper for building a registration request.
+     */
+    private UserRequest req(String username, String email, String password) {
+        UserRequest r = new UserRequest();
+        r.username = username;
+        r.email = email;
+        r.displayName = "Test User";
+        r.password = password;
+        return r;
+    }
+
+    /**
+     * Helper for building an update-style request.
+     */
+    private UserRequest upd(String displayName, String bio, String avatarUrl) {
+        UserRequest u = new UserRequest();
+        u.displayName = displayName;
+        u.bio = bio;
+        u.avatarUrl = avatarUrl;
+        return u;
+    }
+
+    /**
+     * Validates registration: User is persisted, redentials are created and
+     * password is stored as bcrypt hash
+     */
+    @Test
+    void registerCreatesUserAndHashedCredentials() {
+        String raw = "Password@123";
+
+        // When registering a new user
+        User u = userService.register(req("ian0", "ian0@arizona.edu", raw));
+
+        // Then user is persisted and has an ID
+        assertNotNull(u.getId());
+
+        // And credentials exist using the same ID (shared PK mapping)
+        var creds = credsRepository.findById(u.getId()).orElseThrow();
+
+        // And password is NOT stored as plaintext
+        assertNotEquals(raw, creds.getPasswordHash());
+
+        // And bcrypt hash verifies successfully
+        assertTrue(encoder.matches(raw, creds.getPasswordHash()));
+    }
+
+    /**
+     * Validates business rule: username must be unique.
+     */
+    @Test
+    void registerRejectsDuplicateUsername() {
+        userService.register(req("xuser", "x@gmail.com", "Password123"));
+
+        // same username but different email - should conflict
+        assertThrows(ConflictException.class, () ->
+                userService.register(req("xuser", "y@gmail.com", "Password123"))
+        );
+    }
+
+    /**
+     * Validates business rule: Email must be unique.
+     */
+    @Test
+    void registerRejectsDuplicateEmail() {
+        userService.register(req("xuser", "x@gmail.com", "Password123"));
+
+        // different username but same email - should conflict
+        assertThrows(ConflictException.class, () ->
+                userService.register(req("yuser", "x@gmail.com", "Password123"))
+        );
+    }
+
+    /**
+     * Validates 1:1 mapping: each user has exactly one credentials record.
+     */
+    @Test
+    void eachUserHasExactlyOneCredentialsRecord() {
+        User u = userService.register(req("ian1", "ian1@arizona.edu", "Password123"));
+
+        // expects exactly 1 credential row after creating 1 user
+        assertEquals(1, credsRepository.count());
+        assertTrue(credsRepository.findById(u.getId()).isPresent());
+    }
+
+    /**
+     * Validates profile update: profile fields change but redentials remain unchanged
+     */
+    @Test
+    void updateUpdatesProfileFieldsAndKeepsCredentialsSame() {
+        // Given an existing user with credentials
+        User u = userService.register(req("ian2", "ian2@arizona.edu", "Password123"));
+
+        // Capture existing password hash (must not change on profile update)
+        String oldHash = credsRepository.findById(u.getId()).orElseThrow().getPasswordHash();
+
+        // When updating profile fields
+        var updated = userService.update(u.getId(),
+                upd("New Display", "New bio", "https://example.com/avatar.png"));
+
+        // Then profile fields update
+        assertEquals("New Display", updated.getDisplayName());
+        assertEquals("New bio", updated.getBio());
+        assertEquals("https://example.com/avatar.png", updated.getAvatarUrl());
+
+        // And credentials unchanged
+        String newHash = credsRepository.findById(u.getId()).orElseThrow().getPasswordHash();
+        assertEquals(oldHash, newHash);
+    }
+
+    /**
+     * Validates cascade delete: deleting User removes associated credentials.
+     */
+    @Test
+    void deleteRemovesUserAndCredentials() {
+        // Given an existing user
+        User u = userService.register(req("ian5", "ian5@arizona.edu", "Password123"));
+
+        Long id = u.getId();
+
+        // Ensure both user and credentials exist before delete
+        assertTrue(userRepository.findById(id).isPresent());
+        assertTrue(credsRepository.findById(id).isPresent());
+
+        // When deleting user
+        userService.delete(id);
+
+        // The user and associated credentials are removed (cascade + orphanRemoval)
+        assertFalse(userRepository.findById(id).isPresent());
+        assertFalse(credsRepository.findById(id).isPresent());
+    }
+
+    /**
+     * Validates error handling: deleting non-existent user throws NotFoundException.
+     */
+    @Test
+    void deleteNonExistingUserThrowsNotFound() {
+        assertThrows(NotFoundException.class, () ->
+                userService.delete(9999L)
+        );
+    }
+}


### PR DESCRIPTION
This PR implements the User and UserCredentials domains.

Added:

- JPA entities with ORM mappings 
- Unique constraints on username and email
- BCrypt password hashing
- Repository interfaces
- Service layer with business rule enforcement
- REST endpoints (POST, GET all, GET by id, PUT, DELETE)
- Unit and JPA tests validating constraints and relationships

This should complete these domain's portion for Phase 1 (data model + repository + REST prototype).

Next step:
- Implement authentication & token layer