### PR TITLE
Fix guest/public video access: enforce VideoVisibility

### DIFF
--- a/src/main/java/edu/arizona/videoshare/controller/AuthController.java
+++ b/src/main/java/edu/arizona/videoshare/controller/AuthController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-import edu.arizona.videoshare.repository.VideoRepository;
+import edu.arizona.videoshare.service.VideoService;
 
 /**
  * AuthController (Presentation Layer)
@@ -33,7 +33,7 @@ public class AuthController {
 
     private final AuthService authService;
     private final VerificationService verificationService;
-    private final VideoRepository videoRepository;
+    private final VideoService videoService;
 
     /**
      * GET /register
@@ -143,7 +143,7 @@ public class AuthController {
      */
     @GetMapping("/")
     public String home(Model model) {
-        model.addAttribute("videos", videoRepository.findAllByOrderByCreatedAtDesc());
+        model.addAttribute("videos", videoService.getAllPublic());
         return "home";
     }
 

--- a/src/main/java/edu/arizona/videoshare/controller/ChannelPageController.java
+++ b/src/main/java/edu/arizona/videoshare/controller/ChannelPageController.java
@@ -2,6 +2,7 @@ package edu.arizona.videoshare.controller;
 
 import edu.arizona.videoshare.model.entity.Channel;
 import edu.arizona.videoshare.service.ChannelService;
+import edu.arizona.videoshare.service.VideoService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 public class ChannelPageController {
 
     private final ChannelService channelService;
+    private final VideoService videoService;
 
     @GetMapping("/{username}/channel/{channelName}")
     public String showChannelPage(
@@ -28,6 +30,9 @@ public class ChannelPageController {
 
         model.addAttribute("channel", channel);
         model.addAttribute("isOwner", isOwner);
+        model.addAttribute("videos", isOwner
+                ? channel.getVideosOnChannel()
+                : videoService.getPublicVideosForChannel(channel.getId()));
 
         return "channel";
     }

--- a/src/main/java/edu/arizona/videoshare/controller/VideoController.java
+++ b/src/main/java/edu/arizona/videoshare/controller/VideoController.java
@@ -21,12 +21,12 @@ public class VideoController {
 
     @GetMapping("/{id}")
     public edu.arizona.videoshare.model.entity.Video get(@PathVariable Long id) {
-        return videoService.get(id);
+        return videoService.getPublic(id);
     }
 
     @GetMapping
     public List<edu.arizona.videoshare.model.entity.Video> getAll() {
-        return videoService.getAll();
+        return videoService.getAllPublic();
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/edu/arizona/videoshare/controller/VideoPageController.java
+++ b/src/main/java/edu/arizona/videoshare/controller/VideoPageController.java
@@ -1,7 +1,7 @@
 package edu.arizona.videoshare.controller;
 
 import edu.arizona.videoshare.model.entity.Video;
-import edu.arizona.videoshare.repository.VideoRepository;
+import edu.arizona.videoshare.service.VideoService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -13,15 +13,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 @RequiredArgsConstructor
 public class VideoPageController {
 
-    private final VideoRepository videoRepository;
+    private final VideoService videoService;
 
     @GetMapping("/videos/{videoId}")
     public String showVideoPage(
             @PathVariable Long videoId,
             HttpSession session,
             Model model) {
-        Video video = videoRepository.findById(videoId)
-                .orElseThrow(() -> new RuntimeException("Video not found"));
+        Video video = videoService.getPublic(videoId);
 
         Long loggedInUserId = (Long) session.getAttribute("loggedInUserId");
 

--- a/src/main/java/edu/arizona/videoshare/model/entity/Video.java
+++ b/src/main/java/edu/arizona/videoshare/model/entity/Video.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
+import edu.arizona.videoshare.model.enums.VideoVisibility;
 
 import java.time.LocalDateTime;
 
@@ -41,6 +42,11 @@ public class Video {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "channel_id", nullable = false)
     private Channel channel;
+
+    @Setter
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private VideoVisibility visibility = VideoVisibility.PUBLIC;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/edu/arizona/videoshare/repository/VideoRepository.java
+++ b/src/main/java/edu/arizona/videoshare/repository/VideoRepository.java
@@ -1,9 +1,11 @@
 package edu.arizona.videoshare.repository;
 
 import edu.arizona.videoshare.model.entity.Video;
+import edu.arizona.videoshare.model.enums.VideoVisibility;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * VideoRepository
@@ -12,4 +14,7 @@ import java.util.List;
  */
 public interface VideoRepository extends JpaRepository<Video, Long> {
     List<Video> findAllByOrderByCreatedAtDesc();
+    List<Video> findAllByVisibilityOrderByCreatedAtDesc(VideoVisibility visibility);
+    Optional<Video> findByIdAndVisibility(Long id, VideoVisibility visibility);
+    List<Video> findAllByChannelIdAndVisibilityOrderByCreatedAtDesc(Long channelId, VideoVisibility visibility);
 }

--- a/src/main/java/edu/arizona/videoshare/service/ChannelService.java
+++ b/src/main/java/edu/arizona/videoshare/service/ChannelService.java
@@ -7,6 +7,7 @@ import edu.arizona.videoshare.model.enums.UserRole;
 import edu.arizona.videoshare.model.enums.UserStatus;
 import edu.arizona.videoshare.repository.ChannelRepository;
 import edu.arizona.videoshare.repository.UserRepository;
+import edu.arizona.videoshare.repository.VideoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +26,7 @@ public class ChannelService {
 
     private final ChannelRepository channelRepository;
     private final UserRepository userRepository;
+    private final VideoRepository videoRepository;
 
     @Transactional(readOnly = true)
     public List<Channel> getChannelsByUserId(Long userId) {
@@ -119,7 +121,9 @@ public class ChannelService {
         Channel channel = channelRepository.findById(channelId)
                 .orElseThrow(() -> new RuntimeException("Channel not found"));
 
-        return channel.getVideosOnChannel();
+        return videoRepository.findAllByChannelIdAndVisibilityOrderByCreatedAtDesc(
+                channel.getId(),
+                edu.arizona.videoshare.model.enums.VideoVisibility.PUBLIC);
     }
 
     @Transactional

--- a/src/main/java/edu/arizona/videoshare/service/VideoService.java
+++ b/src/main/java/edu/arizona/videoshare/service/VideoService.java
@@ -4,12 +4,12 @@ import edu.arizona.videoshare.exception.NotFoundException;
 import edu.arizona.videoshare.model.entity.Channel;
 import edu.arizona.videoshare.model.entity.User;
 import edu.arizona.videoshare.model.entity.Video;
+import edu.arizona.videoshare.model.enums.VideoVisibility;
 import edu.arizona.videoshare.model.enums.UserRole;
 import edu.arizona.videoshare.model.enums.UserStatus;
 import edu.arizona.videoshare.repository.ChannelRepository;
 import edu.arizona.videoshare.repository.UserRepository;
 import edu.arizona.videoshare.repository.VideoRepository;
-import edu.arizona.videoshare.model.entity.Video;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -42,8 +42,21 @@ public class VideoService {
                 .orElseThrow(() -> new NotFoundException("Video not found"));
     }
 
+    public Video getPublic(Long id) {
+        return videoRepository.findByIdAndVisibility(id, VideoVisibility.PUBLIC)
+                .orElseThrow(() -> new NotFoundException("Video not found"));
+    }
+
     public List<Video> getAll() {
         return videoRepository.findAll();
+    }
+
+    public List<Video> getAllPublic() {
+        return videoRepository.findAllByVisibilityOrderByCreatedAtDesc(VideoVisibility.PUBLIC);
+    }
+
+    public List<Video> getPublicVideosForChannel(Long channelId) {
+        return videoRepository.findAllByChannelIdAndVisibilityOrderByCreatedAtDesc(channelId, VideoVisibility.PUBLIC);
     }
 
     public void delete(Long id) {
@@ -89,6 +102,7 @@ public class VideoService {
         video.setTitle(title.trim());
         video.setOwner(user);
         video.setChannel(channel);
+        video.setVisibility(VideoVisibility.PUBLIC);
 
         return videoRepository.save(video);
     }

--- a/src/main/resources/templates/channel.html
+++ b/src/main/resources/templates/channel.html
@@ -71,12 +71,12 @@
         <div id="videosSection" class="channel-section py-4 border-bottom">
             <h3 class="h5 mb-4">Videos</h3>
 
-            <div th:if="${#lists.isEmpty(channel.videosOnChannel)}" class="text-muted">
+            <div th:if="${#lists.isEmpty(videos)}" class="text-muted">
                 No videos found.
             </div>
 
-            <div th:if="${!#lists.isEmpty(channel.videosOnChannel)}" class="row g-4">
-                <div class="col-md-6 col-lg-4" th:each="video : ${channel.videosOnChannel}">
+            <div th:if="${!#lists.isEmpty(videos)}" class="row g-4">
+                <div class="col-md-6 col-lg-4" th:each="video : ${videos}">
                     <a th:href="@{'/videos/' + ${video.id}}"
                        class="text-decoration-none text-dark">
                         <div class="border rounded-4 p-3 h-100 bg-white shadow-sm">

--- a/src/test/java/edu/arizona/videoshare/service/VideoServiceTest.java
+++ b/src/test/java/edu/arizona/videoshare/service/VideoServiceTest.java
@@ -1,0 +1,82 @@
+package edu.arizona.videoshare.service;
+
+import edu.arizona.videoshare.exception.NotFoundException;
+import edu.arizona.videoshare.model.entity.Channel;
+import edu.arizona.videoshare.model.entity.User;
+import edu.arizona.videoshare.model.entity.UserCredentials;
+import edu.arizona.videoshare.model.entity.Video;
+import edu.arizona.videoshare.model.enums.VideoVisibility;
+import edu.arizona.videoshare.repository.ChannelRepository;
+import edu.arizona.videoshare.repository.UserRepository;
+import edu.arizona.videoshare.repository.VideoRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class VideoServiceTest {
+
+    @Autowired VideoService videoService;
+    @Autowired VideoRepository videoRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired ChannelRepository channelRepository;
+
+    @Test
+    void getAllPublicReturnsOnlyPublicVideos() {
+        Channel channel = saveChannel("creator-publics", "publics-channel");
+
+        saveVideo(channel, "Public Video", VideoVisibility.PUBLIC);
+        saveVideo(channel, "Private Video", VideoVisibility.PRIVATE);
+
+        List<Video> videos = videoService.getAllPublic();
+
+        assertEquals(1, videos.size());
+        assertEquals("Public Video", videos.get(0).getTitle());
+        assertEquals(VideoVisibility.PUBLIC, videos.get(0).getVisibility());
+    }
+
+    @Test
+    void getPublicRejectsPrivateVideo() {
+        Channel channel = saveChannel("creator-private", "private-channel");
+        Video privateVideo = saveVideo(channel, "Hidden Video", VideoVisibility.PRIVATE);
+
+        assertThrows(NotFoundException.class, () -> videoService.getPublic(privateVideo.getId()));
+    }
+
+    private Channel saveChannel(String username, String channelName) {
+        User user = new User();
+        user.setUsername(username);
+        user.setEmail(username + "@example.com");
+        user.setDisplayName(username);
+
+        UserCredentials credentials = new UserCredentials();
+        credentials.setPasswordHash("$2a$10$dummyDummyDummyDummyDummyDummyDummyDummyDummyDummy");
+        user.attachCredentials(credentials);
+
+        User savedUser = userRepository.save(user);
+
+        Channel channel = new Channel();
+        channel.setName(channelName);
+        channel.setUser(savedUser);
+
+        return channelRepository.save(channel);
+    }
+
+    private Video saveVideo(Channel channel, String title, VideoVisibility visibility) {
+        Video video = new Video();
+        video.setTitle(title);
+        video.setOwner(channel.getUser());
+        video.setChannel(channel);
+        video.setVisibility(visibility);
+        return videoRepository.save(video);
+    }
+}


### PR DESCRIPTION
- Video.java, VideoRepository.java, VideoService.java: store VideoVisibility; guest reads use public-only methods (findAllByVisibility..., getPublic(...))
- Guest entry points updated: home (AuthController), playback (VideoPageController), API browsing/viewing (VideoController), channels (ChannelPageController + channel.html)
- Added VideoServiceTest to verify only public videos are returned to guests; private videos cannot be viewed publicly