### PR TITLE
(FIX) As a user, I want to deactivate my account so that I can leave the platform.

### DIFF
--- a/src/main/java/edu/arizona/videoshare/controller/AuthController.java
+++ b/src/main/java/edu/arizona/videoshare/controller/AuthController.java
@@ -121,7 +121,7 @@ public class AuthController {
 
             return "redirect:/";
         } catch (IllegalArgumentException ex) {
-            bindingResult.reject("login.failed", "Invalid username/email or password");
+            bindingResult.reject("login.failed", ex.getMessage());
             return "auth/login";
         }
     }

--- a/src/main/java/edu/arizona/videoshare/controller/YouController.java
+++ b/src/main/java/edu/arizona/videoshare/controller/YouController.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.List;
 
@@ -39,5 +41,20 @@ public class YouController {
         model.addAttribute("isCreator", user.getRole() == UserRole.CREATOR);
 
         return "you";
+    }
+
+    @PostMapping("/you/deactivate")
+    public String deactivateAccount(HttpSession session, RedirectAttributes redirectAttributes) {
+        Long loggedInUserId = (Long) session.getAttribute("loggedInUserId");
+
+        if (loggedInUserId == null) {
+            redirectAttributes.addFlashAttribute("errorMessage", "You must be signed in to deactivate your account.");
+            return "redirect:/login";
+        }
+
+        userService.deactivate(loggedInUserId);
+        session.invalidate();
+        redirectAttributes.addFlashAttribute("successMessage", "Your account has been deactivated.");
+        return "redirect:/";
     }
 }

--- a/src/main/java/edu/arizona/videoshare/service/AuthService.java
+++ b/src/main/java/edu/arizona/videoshare/service/AuthService.java
@@ -76,6 +76,9 @@ public class AuthService {
         User user = users.findByUsernameIgnoreCaseOrEmailIgnoreCase(identifier, identifier)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid username/email or password"));
 
+        if (user.getStatus() == UserStatus.DELETED) {
+            throw new IllegalArgumentException("This account has been deactivated");
+        }
         if (user.getStatus() != UserStatus.ACTIVE) {
             throw new IllegalArgumentException("Please verify your email before signing in");
         }

--- a/src/main/java/edu/arizona/videoshare/service/UserService.java
+++ b/src/main/java/edu/arizona/videoshare/service/UserService.java
@@ -4,6 +4,7 @@ import edu.arizona.videoshare.dto.user.RegisterForm;
 import edu.arizona.videoshare.dto.user.UserRequest;
 import edu.arizona.videoshare.exception.NotFoundException;
 import edu.arizona.videoshare.model.entity.User;
+import edu.arizona.videoshare.model.enums.UserStatus;
 import edu.arizona.videoshare.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -66,6 +67,18 @@ public class UserService {
         if (req.bio != null) user.setBio(req.bio.trim());
         if (req.avatarUrl != null) user.setAvatarUrl(req.avatarUrl.trim());
 
+        return users.save(user);
+    }
+
+    /**
+     * UPDATE: Marks a user account as deactivated without removing persisted data.
+     */
+    @Transactional
+    public User deactivate(Long id) {
+        User user = users.findById(id)
+                .orElseThrow(() -> new NotFoundException("User not found: " + id));
+
+        user.setStatus(UserStatus.DELETED);
         return users.save(user);
     }
 

--- a/src/main/java/edu/arizona/videoshare/service/VerificationService.java
+++ b/src/main/java/edu/arizona/videoshare/service/VerificationService.java
@@ -47,6 +47,10 @@ public class VerificationService {
         User user = users.findByEmailIgnoreCase(email)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
+        if (user.getStatus() == UserStatus.DELETED) {
+            throw new IllegalArgumentException("This account has been deactivated");
+        }
+
         if (user.getStatus() == UserStatus.ACTIVE) {
             throw new IllegalArgumentException("Account already verified");
         }

--- a/src/main/resources/templates/you.html
+++ b/src/main/resources/templates/you.html
@@ -188,6 +188,24 @@
             </div>
         </section>
 
+        <section class="you-section border border-danger-subtle rounded-4 p-4 bg-danger-subtle bg-opacity-10">
+            <div class="d-flex flex-column flex-md-row align-items-start align-items-md-center justify-content-between gap-3">
+                <div>
+                    <h3 class="h5 mb-1 text-danger">Deactivate Account</h3>
+                    <p class="mb-0 text-secondary">
+                        Deactivating your account signs you out and prevents future sign-ins.
+                    </p>
+                </div>
+
+                <form th:action="@{/you/deactivate}" method="post"
+                      onsubmit="return confirm('Deactivate your account? You will be signed out immediately.');">
+                    <button type="submit" class="btn btn-danger rounded-pill px-4">
+                        Deactivate Account
+                    </button>
+                </form>
+            </div>
+        </section>
+
     </div>
 
     <!-- Create Channel Modal -->

--- a/src/test/java/edu/arizona/videoshare/service/UserServiceTest.java
+++ b/src/test/java/edu/arizona/videoshare/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package edu.arizona.videoshare.service;
 import edu.arizona.videoshare.dto.user.UserRequest;
 import edu.arizona.videoshare.exception.ConflictException;
 import edu.arizona.videoshare.model.entity.User;
+import edu.arizona.videoshare.model.enums.UserStatus;
 import edu.arizona.videoshare.repository.UserCredentialsRepository;
 import edu.arizona.videoshare.repository.UserRepository;
 import edu.arizona.videoshare.exception.NotFoundException;
@@ -169,6 +170,24 @@ class UserServiceTest {
     void deleteNonExistingUserThrowsNotFound() {
         assertThrows(NotFoundException.class, () ->
                 userService.delete(9999L)
+        );
+    }
+
+    @Test
+    void deactivateMarksUserAsDeletedAndKeepsCredentials() {
+        User u = userService.register(req("ian6", "ian6@arizona.edu", "Password123"));
+
+        User deactivated = userService.deactivate(u.getId());
+
+        assertEquals(UserStatus.DELETED, deactivated.getStatus());
+        assertTrue(userRepository.findById(u.getId()).isPresent());
+        assertTrue(credsRepository.findById(u.getId()).isPresent());
+    }
+
+    @Test
+    void deactivateNonExistingUserThrowsNotFound() {
+        assertThrows(NotFoundException.class, () ->
+                userService.deactivate(9998L)
         );
     }
 }


### PR DESCRIPTION
Implemented account deactivation as a soft-delete flow so users can leave the platform without physically removing their data. The new POST action in YouController.java (line 46) deactivates the logged-in account, invalidates the session, and redirects home with a flash message. The actual status change lives in UserService.java (line 73).

I also made auth consistent with that state: deactivated accounts now get blocked from sign-in in AuthService.java (line 79), the login page will show the real reason in AuthController.java (line 123), and re-verification is rejected for deactivated users in VerificationService.java (line 46).

On the UI side, I added a “Deactivate Account” danger section with confirmation to you.html (line 191). I also added service tests covering successful deactivation and the not-found case in UserServiceTest.java (line 176).

Verification: .\mvnw.cmd -q -Dtest=UserServiceTest test passed with 9 tests, 0 failures.

Assumption used: “deactivate” means soft delete by setting UserStatus.DELETED, not hard deletion.