### PR TITLE
Issue 153, 160, and 163

### DIFF
--- a/src/main/java/edu/arizona/videoshare/controller/AuthController.java
+++ b/src/main/java/edu/arizona/videoshare/controller/AuthController.java
@@ -71,8 +71,7 @@ public class AuthController {
 
             redirectAttributes.addFlashAttribute(
                     "successMessage",
-                    "Account created successfully."
-            );
+                    "Account created successfully.");
             return "redirect:/login";
 
         } catch (ConflictException ex) {
@@ -146,8 +145,7 @@ public class AuthController {
      * Returns the application home page.
      */
     @GetMapping("/")
-    public String home(Model model) {
-        model.addAttribute("videos", videoService.getAllPublic());
+    public String home() {
         return "home";
     }
 

--- a/src/main/java/edu/arizona/videoshare/model/entity/Channel.java
+++ b/src/main/java/edu/arizona/videoshare/model/entity/Channel.java
@@ -27,7 +27,7 @@ import jakarta.validation.constraints.NotNull;
 @Setter
 @Entity
 public class Channel {
-    
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -47,25 +47,22 @@ public class Channel {
 
     private Long subscriberCount = 0L;
 
-
     @NotNull
     @ManyToOne(optional = false)
     @JoinColumn(name = "user_id")
-    @JsonIgnoreProperties({"channels", "credentials"})
+    @JsonIgnoreProperties({ "channels", "credentials" })
     private User user;
 
     @OneToMany(mappedBy = "channel")
+    @JsonIgnore
     private List<Video> videosOnChannel;
 
     @OneToMany(mappedBy = "channel", fetch = FetchType.LAZY)
     @JsonIgnore
     private List<Subscription> subscribers;
 
-
     public Channel() {
 
     }
-
-
 
 }

--- a/src/main/java/edu/arizona/videoshare/model/entity/User.java
+++ b/src/main/java/edu/arizona/videoshare/model/entity/User.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.time.LocalDateTime;
 
@@ -112,8 +113,9 @@ public class User {
      * 1:1 relationship to credentials (authentication data).
      * Business Rule: Each User should have exactly one UserCredentials record.
      */
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, optional = false, fetch = FetchType.LAZY)
 
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, optional = false, fetch = FetchType.LAZY)
+    @JsonIgnore
     private UserCredentials credentials;
 
     public User() {

--- a/src/main/java/edu/arizona/videoshare/model/entity/Video.java
+++ b/src/main/java/edu/arizona/videoshare/model/entity/Video.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 import edu.arizona.videoshare.model.enums.VideoVisibility;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.time.LocalDateTime;
 
@@ -16,6 +17,7 @@ import java.time.LocalDateTime;
  * Minimal implementation so other domains (like PlaylistVideo) can reference
  * it.
  */
+
 @Getter
 @Entity
 @Table(name = "videos")
@@ -38,12 +40,15 @@ public class Video {
     @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_user_id", foreignKey = @ForeignKey(name = "fk_videos_owner_user"))
+
+    @JsonIgnoreProperties({ "credentials" })
     private User owner;
 
     // Added this to make the channel and subscription entities work
     @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "channel_id", nullable = false)
+    @JsonIgnoreProperties({ "videosOnChannel", "subscribers", "user" })
     private Channel channel;
 
     @Column(nullable = false)

--- a/src/main/java/edu/arizona/videoshare/repository/ViewEventRepository.java
+++ b/src/main/java/edu/arizona/videoshare/repository/ViewEventRepository.java
@@ -1,13 +1,16 @@
 package edu.arizona.videoshare.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import edu.arizona.videoshare.model.entity.ViewEvent;
 
-public interface ViewEventRepository extends JpaRepository<ViewEvent, Long>{
-    List<ViewEvent> findByUserId(Long userId);
-    
+public interface ViewEventRepository extends JpaRepository<ViewEvent, Long> {
+    List<ViewEvent> findByUserIdOrderByWatchedAtDesc(Long userId);
+
     List<ViewEvent> findByVideoId(Long videoId);
+
+    Optional<ViewEvent> findByUserIdAndVideoId(Long userId, Long videoId);
 }

--- a/src/main/java/edu/arizona/videoshare/service/ViewEventService.java
+++ b/src/main/java/edu/arizona/videoshare/service/ViewEventService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import edu.arizona.videoshare.model.entity.ViewEvent;
 import edu.arizona.videoshare.repository.ViewEventRepository;
 import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -26,17 +27,23 @@ public class ViewEventService {
 
     @Transactional
     public CreateViewEventResponse createViewEvent(CreateViewEventRequest request) {
-        User user = userRepository.findById(request.getUserId()).orElseThrow(() ->
-                new NotFoundException("User not found: " + request.getUserId()));
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new NotFoundException("User not found: " + request.getUserId()));
 
-        Video video = videoRepository.findById(request.getVideoId()).orElseThrow(() ->
-                new NotFoundException("Video not found: " + request.getVideoId()));
+        Video video = videoRepository.findById(request.getVideoId())
+                .orElseThrow(() -> new NotFoundException("Video not found: " + request.getVideoId()));
 
-        ViewEvent viewEvent = new ViewEvent();
-        viewEvent.setUser(user);
-        viewEvent.setVideo(video);
-        viewEvent.setWatchDuration(0);
-        viewEvent.setCompleted(false);
+        ViewEvent viewEvent = viewEventRepository.findByUserIdAndVideoId(user.getId(), video.getId())
+                .orElseGet(() -> {
+                    ViewEvent newViewEvent = new ViewEvent();
+                    newViewEvent.setUser(user);
+                    newViewEvent.setVideo(video);
+                    newViewEvent.setWatchDuration(0);
+                    newViewEvent.setCompleted(false);
+                    return newViewEvent;
+                });
+
+        viewEvent.setWatchedAt(LocalDateTime.now());
 
         ViewEvent saved = viewEventRepository.save(viewEvent);
 
@@ -45,8 +52,8 @@ public class ViewEventService {
 
     @Transactional
     public ViewEventResponse updateWatchDuration(Long viewEventId, int watchDuration) {
-        ViewEvent viewEvent = viewEventRepository.findById(viewEventId).orElseThrow(() ->
-                new NotFoundException("ViewEvent not found: " + viewEventId));
+        ViewEvent viewEvent = viewEventRepository.findById(viewEventId)
+                .orElseThrow(() -> new NotFoundException("ViewEvent not found: " + viewEventId));
 
         viewEvent.setWatchDuration(watchDuration);
 
@@ -62,7 +69,7 @@ public class ViewEventService {
 
     @Transactional(readOnly = true)
     public List<ViewEvent> getUserHistory(Long userId) {
-        return viewEventRepository.findByUserId(userId);
+        return viewEventRepository.findByUserIdOrderByWatchedAtDesc(userId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -4,43 +4,99 @@
 
 <th:block th:fragment="content">
     <div class="container py-5">
-
         <section>
             <div class="d-flex justify-content-between align-items-center mb-4">
                 <h2 class="h4 mb-0">Recent Videos</h2>
             </div>
 
-            <div th:if="${videos == null or #lists.isEmpty(videos)}" class="text-muted">
+            <!-- Loading indicator -->
+            <div id="videosLoading" class="text-center py-5">
+                <div class="spinner-border text-dark" role="status"></div>
+                <div class="mt-3 text-muted">Loading videos...</div>
+            </div>
+
+            <!-- Error message -->
+            <div id="videosError" class="text-danger d-none">
+                Could not load videos.
+            </div>
+
+            <!-- Empty state -->
+            <div id="videosEmpty" class="text-muted d-none">
                 No videos available yet.
             </div>
 
-            <div th:if="${videos != null and !#lists.isEmpty(videos)}" class="row g-4">
-                <div class="col-12 col-md-6 col-lg-4" th:each="video : ${videos}">
-                    <a th:href="@{'/videos/' + ${video.id}}"
-                       class="text-decoration-none text-dark">
-                        <div class="card h-100 border-0 shadow-sm rounded-4">
-                            <div class="bg-dark text-white d-flex align-items-center justify-content-center rounded-top-4"
-                                 style="height: 180px;">
-                                <i class="bi bi-play-btn fs-1"></i>
-                            </div>
-
-                            <div class="card-body">
-                                <h5 class="card-title mb-2" th:text="${video.title}">Video Title</h5>
-
-                                <div class="text-muted small mb-1">
-                                    <span th:text="${video.channel != null ? video.channel.name : 'Unknown Channel'}">Channel Name</span>
-                                </div>
-
-                                <div class="text-muted small" th:if="${video.createdAt != null}"
-                                     th:text="'Uploaded ' + ${#temporals.format(video.createdAt, 'MMM d, yyyy')}">
-                                    Uploaded date
-                                </div>
-                            </div>
-                        </div>
-                    </a>
-                </div>
-            </div>
+            <!-- Video grid -->
+            <div id="videosGrid" class="row g-4 d-none"></div>
         </section>
     </div>
+
+    <script>
+        document.addEventListener("DOMContentLoaded", async function () {
+            const videosLoading = document.getElementById("videosLoading");
+            const videosError = document.getElementById("videosError");
+            const videosEmpty = document.getElementById("videosEmpty");
+            const videosGrid = document.getElementById("videosGrid");
+
+            try {
+                const res = await fetch("/api/videos");
+                if (!res.ok) throw new Error("Failed to load videos");
+
+                const videos = await res.json();
+
+                videosLoading.classList.add("d-none");
+
+                if (!videos || videos.length === 0) {
+                    videosEmpty.classList.remove("d-none");
+                    return;
+                }
+
+                videosGrid.innerHTML = videos.map(video => `
+                    <div class="col-12 col-md-6 col-lg-4">
+                        <a href="/videos/${video.id}" class="text-decoration-none text-dark">
+                            <div class="card h-100 border-0 shadow-sm rounded-4">
+                                <div class="bg-dark text-white d-flex align-items-center justify-content-center rounded-top-4"
+                                     style="height: 180px;">
+                                    <i class="bi bi-play-btn fs-1"></i>
+                                </div>
+
+                                <div class="card-body">
+                                    <h5 class="card-title mb-2">${escapeHtml(video.title || "Untitled Video")}</h5>
+
+                                    <div class="text-muted small mb-1">
+                                        ${escapeHtml(video.channel?.name || "Unknown Channel")}
+                                    </div>
+
+                                    <div class="text-muted small">
+                                        ${formatUploadedDate(video.createdAt)}
+                                    </div>
+                                </div>
+                            </div>
+                        </a>
+                    </div>
+                `).join("");
+
+                videosGrid.classList.remove("d-none");
+            } catch (e) {
+                videosLoading.classList.add("d-none");
+                videosError.classList.remove("d-none");
+            }
+
+            function escapeHtml(str) {
+                const div = document.createElement("div");
+                div.textContent = str || "";
+                return div.innerHTML;
+            }
+
+            function formatUploadedDate(iso) {
+                if (!iso) return "";
+                const d = new Date(iso);
+                return `Uploaded ${d.toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                    year: "numeric"
+                })}`;
+            }
+        });
+    </script>
 </th:block>
 </html>

--- a/src/main/resources/templates/video.html
+++ b/src/main/resources/templates/video.html
@@ -10,9 +10,10 @@
             <!-- Main Video Area -->
             <div class="col-lg-8">
                <div class="bg-dark rounded-4 shadow-sm overflow-hidden">
-    <video th:if="${video.mediaUrl != null and !#strings.isEmpty(video.mediaUrl)}"
-           class="w-100 d-block"
-           controls
+   <video id="videoPlayer"
+       th:if="..."
+       class="w-100 d-block"
+       controls
            preload="metadata"
            style="max-height: 480px; background-color: #000;"
            th:src="${video.mediaUrl}">
@@ -220,14 +221,51 @@
             const commentHeader = document.getElementById("commentHeader");
             const playlistAddMessage = document.getElementById("playlistAddMessage");
 
-            loadComments();
-            if (userId) {
-                fetch('/api/views', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ userId: userId, videoId: videoId })
-                }).catch(() => {});
-            }
+           loadComments();
+
+const videoPlayer = document.getElementById("videoPlayer");
+let viewEventId = null;
+let maxSecondsWatched = 0;
+
+if (userId && videoPlayer) {
+    // create view event
+    fetch('/api/views', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: userId, videoId: videoId })
+    })
+    .then(res => {
+        if (!res.ok) throw new Error();
+        return res.json();
+    })
+    .then(data => {
+        viewEventId = data.id;
+    })
+    .catch(() => {});
+
+    // track watch time
+    videoPlayer.addEventListener("timeupdate", function () {
+        const seconds = Math.floor(videoPlayer.currentTime);
+        if (seconds > maxSecondsWatched) {
+            maxSecondsWatched = seconds;
+        }
+    });
+
+    // send to backend
+    function sendWatchDuration() {
+        if (!viewEventId) return;
+
+        fetch(`/api/views/${viewEventId}/duration`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ watchDuration: maxSecondsWatched })
+        }).catch(() => {});
+    }
+
+    videoPlayer.addEventListener("pause", sendWatchDuration);
+    videoPlayer.addEventListener("ended", sendWatchDuration);
+    window.addEventListener("beforeunload", sendWatchDuration);
+}
 
             // Reactions
             loadReactions();

--- a/src/main/resources/templates/you.html
+++ b/src/main/resources/templates/you.html
@@ -282,9 +282,14 @@
                                     <div class="fw-semibold text-truncate" th:text="${view.video.title}">Video Title</div>
                                     <div class="text-muted small" th:text="${view.video.channel != null ? view.video.channel.name : ''}">Channel</div>
                                     <div class="text-muted small">
-                                        <span th:text="${view.watchDuration}">0</span>s watched
-                                        <span th:if="${view.completed}" class="badge bg-success-subtle text-success ms-1">Completed</span>
-                                    </div>
+    <span th:text="${view.watchDuration}">0</span>s watched
+    <span th:if="${view.completed}" class="badge bg-success-subtle text-success ms-1">Completed</span>
+</div>
+
+<div class="text-muted small" th:if="${view.watchedAt != null}"
+     th:text="|Watched ${#temporals.format(view.watchedAt, 'MMM d, yyyy h:mm a')}|">
+    Watched date
+</div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Watch history refresh behavior.

Updated watch history to keep one entry per user per video
Rewatching a video now updates the existing history entry instead of creating duplicates
Refreshes watchedAt when a video is watched again
Keeps history ordered by most recently watched first
Ensures revisited videos move to the top of the history list

Loading indicator + video API fix.

Updated home page to fetch videos using JavaScript instead of server-side rendering
Added loading spinner while videos are being retrieved from /api/videos
Added empty state and error handling for failed video loads
Fixed infinite JSON recursion between Video, Channel, User, and UserCredentials
Used Jackson annotations (@JsonIgnore, @JsonIgnoreProperties) to prevent circular serialization
Ensured videos load correctly without backend crashes
Improved UI responsiveness and user experience during video loading