### PR TITLE
Report function, admin changes, user history, subscribed videos, and quality of life update

### DIFF
--- a/src/main/java/edu/arizona/videoshare/controller/AuthController.java
+++ b/src/main/java/edu/arizona/videoshare/controller/AuthController.java
@@ -121,6 +121,7 @@ public class AuthController {
             session.setAttribute("loggedInUserId", user.getId());
             session.setAttribute("loggedInUsername", user.getUsername());
             session.setAttribute("loggedInDisplayName", user.getDisplayName());
+            session.setAttribute("loggedInRole", user.getRole());
 
             return "redirect:/";
         } catch (IllegalArgumentException ex) {

--- a/src/main/java/edu/arizona/videoshare/controller/ChannelController.java
+++ b/src/main/java/edu/arizona/videoshare/controller/ChannelController.java
@@ -91,8 +91,11 @@ public class ChannelController {
             throw new ForbiddenException("Authentication required");
         }
 
-        if (!channel.getUser().getId().equals(userId)) {
-            throw new ForbiddenException("You are not the owner of this channel");
+        Object roleObj = request.getSession().getAttribute("loggedInRole");
+        boolean isAdmin = roleObj != null && roleObj.toString().equals("ADMIN");
+
+        if (!channel.getUser().getId().equals(userId) && !isAdmin) {
+            throw new ForbiddenException("You are not authorized");
         }
 
         channel.setName(updatedChannel.getName());
@@ -113,8 +116,11 @@ public class ChannelController {
             throw new ForbiddenException("Authentication required");
         }
 
-        if (!channel.getUser().getId().equals(userId)) {
-            throw new ForbiddenException("You are not the owner of this channel");
+        Object roleObj = request.getSession().getAttribute("loggedInRole");
+        boolean isAdmin = roleObj != null && roleObj.toString().equals("ADMIN");
+
+        if (!channel.getUser().getId().equals(userId) && !isAdmin) {
+            throw new ForbiddenException("You are not authorized");
         }
 
         channelRepository.deleteById(channelId);

--- a/src/main/java/edu/arizona/videoshare/controller/GlobalModelAttributes.java
+++ b/src/main/java/edu/arizona/videoshare/controller/GlobalModelAttributes.java
@@ -1,8 +1,10 @@
 package edu.arizona.videoshare.controller;
 
 import edu.arizona.videoshare.model.entity.Channel;
+import edu.arizona.videoshare.model.entity.Subscription;
 import edu.arizona.videoshare.repository.ChannelRepository;
 import edu.arizona.videoshare.repository.NotificationRepository;
+import edu.arizona.videoshare.repository.SubscriptionRepository;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -17,6 +19,7 @@ public class GlobalModelAttributes {
 
     private final ChannelRepository channelRepository;
     private final NotificationRepository notificationRepository;
+    private final SubscriptionRepository subscriptionRepository;
 
     @ModelAttribute("channels")
     public List<Channel> channels(HttpSession session) {
@@ -29,12 +32,28 @@ public class GlobalModelAttributes {
         return channelRepository.findByUserId(loggedInUserId);
     }
 
+    @ModelAttribute("followedSubscriptions")
+    public List<Subscription> followedSubscriptions(HttpSession session) {
+        Long loggedInUserId = (Long) session.getAttribute("loggedInUserId");
+
+        if (loggedInUserId == null) {
+            return Collections.emptyList();
+        }
+
+        return subscriptionRepository.findBySubscriberIdAndStatusOrderByCreatedAtDesc(
+                loggedInUserId,
+                Subscription.SubscriptionStatus.ACTIVE
+        );
+    }
+
     @ModelAttribute("unreadNotificationCount")
     public long unreadNotificationCount(HttpSession session) {
         Long loggedInUserId = (Long) session.getAttribute("loggedInUserId");
+
         if (loggedInUserId == null) {
             return 0;
         }
+
         return notificationRepository.countByRecipientIdAndIsReadFalse(loggedInUserId);
     }
 }

--- a/src/main/java/edu/arizona/videoshare/controller/LibraryPageController.java
+++ b/src/main/java/edu/arizona/videoshare/controller/LibraryPageController.java
@@ -1,0 +1,86 @@
+package edu.arizona.videoshare.controller;
+
+import edu.arizona.videoshare.model.entity.Channel;
+import edu.arizona.videoshare.model.entity.Subscription;
+import edu.arizona.videoshare.model.entity.Video;
+import edu.arizona.videoshare.model.entity.ViewEvent;
+import edu.arizona.videoshare.service.SubscriptionService;
+import edu.arizona.videoshare.service.VideoService;
+import edu.arizona.videoshare.service.ViewEventService;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Controller
+@RequiredArgsConstructor
+public class LibraryPageController {
+
+    private final VideoService videoService;
+    private final ViewEventService viewEventService;
+    private final SubscriptionService subscriptionService;
+
+    @GetMapping("/subscriptions/videos")
+    public String showSubscribedVideosPage(
+            @RequestParam(required = false) Long channelId,
+            HttpSession session,
+            Model model
+    ) {
+        Long loggedInUserId = (Long) session.getAttribute("loggedInUserId");
+
+        if (loggedInUserId == null) {
+            return "redirect:/login";
+        }
+
+        List<Video> videos = videoService.getSubscribedVideos(loggedInUserId);
+
+        if (channelId != null) {
+            videos = videos.stream()
+                    .filter(video -> video.getChannel() != null
+                            && video.getChannel().getId().equals(channelId))
+                    .toList();
+        }
+
+        Map<Channel, List<Video>> videosByChannel = new LinkedHashMap<>();
+
+        for (Video video : videos) {
+            if (video.getChannel() == null) {
+                continue;
+            }
+
+            videosByChannel.computeIfAbsent(video.getChannel(), c -> new java.util.ArrayList<>())
+                    .add(video);
+        }
+
+        List<Subscription> subscriptions = subscriptionService.getActiveSubscriptionsForUser(loggedInUserId);
+
+        model.addAttribute("subscriptions", subscriptions);
+        model.addAttribute("videosByChannel", videosByChannel);
+        model.addAttribute("selectedChannelId", channelId);
+        model.addAttribute("loggedInUserId", loggedInUserId);
+
+        return "subscribed-videos";
+    }
+
+    @GetMapping("/history")
+    public String showWatchHistoryPage(HttpSession session, Model model) {
+        Long loggedInUserId = (Long) session.getAttribute("loggedInUserId");
+
+        if (loggedInUserId == null) {
+            return "redirect:/login";
+        }
+
+        List<ViewEvent> history = viewEventService.getUserHistory(loggedInUserId);
+
+        model.addAttribute("history", history);
+        model.addAttribute("loggedInUserId", loggedInUserId);
+
+        return "watch-history";
+    }
+}

--- a/src/main/java/edu/arizona/videoshare/controller/ReportController.java
+++ b/src/main/java/edu/arizona/videoshare/controller/ReportController.java
@@ -1,0 +1,82 @@
+package edu.arizona.videoshare.controller;
+
+import edu.arizona.videoshare.dto.report.CreateReportRequest;
+import edu.arizona.videoshare.dto.report.ReportResponse;
+import edu.arizona.videoshare.exception.ForbiddenException;
+import edu.arizona.videoshare.service.ReportService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/reports")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    private void requireLogin(HttpServletRequest request) {
+        Object userId = request.getSession().getAttribute("loggedInUserId");
+
+        if (userId == null) {
+            throw new ForbiddenException("Authentication required");
+        }
+    }
+
+    private void requireAdmin(HttpServletRequest request) {
+        Object roleObj = request.getSession().getAttribute("loggedInRole");
+
+        if (roleObj == null) {
+            throw new ForbiddenException("Authentication required");
+        }
+
+        if (!roleObj.toString().equals("ADMIN")) {
+            throw new ForbiddenException("Admin access required");
+        }
+    }
+
+    @PostMapping
+    public ReportResponse createReport(
+            @Valid @RequestBody CreateReportRequest req,
+            HttpServletRequest request
+    ) {
+        requireLogin(request);
+
+        Long reporterUserId = (Long) request.getSession().getAttribute("loggedInUserId");
+
+        return ReportResponse.of(reportService.createReport(reporterUserId, req));
+    }
+
+    @GetMapping
+    public List<ReportResponse> getAllReports(HttpServletRequest request) {
+        requireAdmin(request);
+
+        return reportService.getAllReports()
+                .stream()
+                .map(ReportResponse::of)
+                .toList();
+    }
+
+    @GetMapping("/open")
+    public List<ReportResponse> getOpenReports(HttpServletRequest request) {
+        requireAdmin(request);
+
+        return reportService.getOpenReports()
+                .stream()
+                .map(ReportResponse::of)
+                .toList();
+    }
+
+    @PutMapping("/{id}/resolve")
+    public ReportResponse resolveReport(
+            @PathVariable Long id,
+            HttpServletRequest request
+    ) {
+        requireAdmin(request);
+
+        return ReportResponse.of(reportService.resolveReport(id));
+    }
+}

--- a/src/main/java/edu/arizona/videoshare/controller/UserController.java
+++ b/src/main/java/edu/arizona/videoshare/controller/UserController.java
@@ -2,7 +2,9 @@ package edu.arizona.videoshare.controller;
 
 import edu.arizona.videoshare.dto.user.UserRequest;
 import edu.arizona.videoshare.dto.user.UserResponse;
+import edu.arizona.videoshare.exception.ForbiddenException;
 import edu.arizona.videoshare.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -10,12 +12,6 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
-/**
- * UserController (Presentation Layer)
- *
- * Exposes REST endpoints for managing User resources.
- * Base path: /api/users
- */
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/users")
@@ -23,50 +19,39 @@ public class UserController {
 
     private final UserService service;
 
-//    public UserController(UserService service) {
-//        this.service = service;
-//    }
+    private void requireAdmin(HttpServletRequest request) {
+        Object roleObj = request.getSession().getAttribute("loggedInRole");
 
-    /**
-     * POST /api/users
-     * Registers a new user.
-     * HTTP 201 Created on success.
-     */
+        if (roleObj == null) {
+            throw new ForbiddenException("Authentication required");
+        }
+
+        if (!roleObj.toString().equals("ADMIN")) {
+            throw new ForbiddenException("Admin access required");
+        }
+    }
+
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public UserResponse register(
-            @Valid @RequestBody UserRequest req) {
+    public UserResponse register(@Valid @RequestBody UserRequest req) {
         return UserResponse.of(service.register(req));
     }
 
-    /**
-     * GET /api/users
-     * Returns all users. List of DTOs.
-     */
     @GetMapping
-    public List<UserResponse> getAll() {
+    public List<UserResponse> getAll(HttpServletRequest request) {
+        requireAdmin(request);
+
         return service.getAll()
                 .stream()
                 .map(UserResponse::of)
                 .toList();
     }
 
-    /**
-     * GET /api/users/{id}
-     * Returns a single user by id.
-     * Mapped globally to HTTP 404
-     */
     @GetMapping("/{id}")
-    public UserResponse getById(
-            @PathVariable Long id) {
+    public UserResponse getById(@PathVariable Long id) {
         return UserResponse.of(service.getById(id));
     }
 
-    /**
-     * PUT /api/users/{id}
-     * Updates profile fields for a user.
-     * HTTP 200 OK on success.
-     */
     @PutMapping("/{id}")
     public UserResponse update(
             @PathVariable Long id,
@@ -75,15 +60,22 @@ public class UserController {
         return UserResponse.of(service.update(id, req));
     }
 
-    /**
-     * DELETE /api/users/{id}
-     * Deletes a user and cascades removal of associated credentials.
-     * HTTP 204 No Content on success.
-     */
+    @PutMapping("/{id}/suspend")
+    public UserResponse suspendUser(@PathVariable Long id, HttpServletRequest request) {
+        requireAdmin(request);
+        return UserResponse.of(service.suspend(id));
+    }
+
+    @PutMapping("/{id}/unlock")
+    public UserResponse unlockUser(@PathVariable Long id, HttpServletRequest request) {
+        requireAdmin(request);
+        return UserResponse.of(service.unlock(id));
+    }
+
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(
-            @PathVariable Long id) {
+    public void delete(@PathVariable Long id, HttpServletRequest request) {
+        requireAdmin(request);
         service.delete(id);
     }
 }

--- a/src/main/java/edu/arizona/videoshare/controller/UserProfilePageController.java
+++ b/src/main/java/edu/arizona/videoshare/controller/UserProfilePageController.java
@@ -1,0 +1,40 @@
+package edu.arizona.videoshare.controller;
+
+import edu.arizona.videoshare.model.entity.Channel;
+import edu.arizona.videoshare.model.entity.User;
+import edu.arizona.videoshare.service.ChannelService;
+import edu.arizona.videoshare.service.UserService;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class UserProfilePageController {
+
+    private final UserService userService;
+    private final ChannelService channelService;
+
+    @GetMapping("/users/{username}")
+    public String showUserProfile(
+            @PathVariable String username,
+            HttpSession session,
+            Model model
+    ) {
+        User user = userService.getByUsername(username);
+        List<Channel> channels = channelService.getChannelsByUserId(user.getId());
+
+        Long loggedInUserId = (Long) session.getAttribute("loggedInUserId");
+
+        model.addAttribute("profileUser", user);
+        model.addAttribute("profileChannels", channels);
+        model.addAttribute("loggedInUserId", loggedInUserId);
+
+        return "user-profile";
+    }
+}

--- a/src/main/java/edu/arizona/videoshare/controller/VideoController.java
+++ b/src/main/java/edu/arizona/videoshare/controller/VideoController.java
@@ -21,11 +21,28 @@ public class VideoController {
     private final VideoService videoService;
     private final ChannelRepository channelRepository;
 
-    @PostMapping("/channel/{channelId}/videos")
-    public edu.arizona.videoshare.model.entity.Video create(@PathVariable Long channelId, @RequestParam("file") MultipartFile file, @RequestParam("title") String title, HttpServletRequest request) {
-        Channel channel = channelRepository.findById(channelId).orElseThrow(() -> new RuntimeException("Channel not found"));
+    private void requireAdmin(HttpServletRequest request) {
+        Object roleObj = request.getSession().getAttribute("loggedInRole");
 
-        //Checking if user is logged in and is the owner of the channel
+        if (roleObj == null) {
+            throw new ForbiddenException("Authentication required");
+        }
+
+        if (!roleObj.toString().equals("ADMIN")) {
+            throw new ForbiddenException("Admin access required");
+        }
+    }
+
+    @PostMapping("/channel/{channelId}/videos")
+    public Video create(
+            @PathVariable Long channelId,
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("title") String title,
+            HttpServletRequest request
+    ) {
+        Channel channel = channelRepository.findById(channelId)
+                .orElseThrow(() -> new RuntimeException("Channel not found"));
+
         Long userId = (Long) request.getSession().getAttribute("loggedInUserId");
         if (userId == null) {
             throw new ForbiddenException("Authentication required");
@@ -39,12 +56,12 @@ public class VideoController {
     }
 
     @GetMapping("/{id}")
-    public edu.arizona.videoshare.model.entity.Video get(@PathVariable Long id) {
+    public Video get(@PathVariable Long id) {
         return videoService.getPublic(id);
     }
 
     @GetMapping
-    public List<edu.arizona.videoshare.model.entity.Video> getAll() {
+    public List<Video> getAll() {
         return videoService.getAllPublic();
     }
 
@@ -54,7 +71,8 @@ public class VideoController {
     }
 
     @DeleteMapping("/{id}")
-    public void delete(@PathVariable Long id) {
+    public void delete(@PathVariable Long id, HttpServletRequest request) {
+        requireAdmin(request);
         videoService.delete(id);
     }
 }

--- a/src/main/java/edu/arizona/videoshare/controller/YouController.java
+++ b/src/main/java/edu/arizona/videoshare/controller/YouController.java
@@ -42,7 +42,11 @@ public class YouController {
 
         model.addAttribute("user", user);
         model.addAttribute("channels", channels);
-        model.addAttribute("history", viewEventService.getUserHistory(user.getId()));
+        model.addAttribute("historyPreview", viewEventService.getUserHistory(user.getId())
+                .stream()
+                .limit(6)
+                .toList());
+
         model.addAttribute("isVerified", user.getStatus() == UserStatus.ACTIVE);
 
         //FIXME: Changed to true for demo purposes, previous line commented below this lines
@@ -52,7 +56,10 @@ public class YouController {
         model.addAttribute("isCreator", user.getRole() == UserRole.CREATOR);
         model.addAttribute("playlists", playlistService.getByUser(user.getId()));
         model.addAttribute("likedVideosPlaylist", playlistService.findLikedVideosPlaylist(user.getId()).orElse(null));
-        model.addAttribute("subscribedVideos", videoService.getSubscribedVideos(user.getId()));
+        model.addAttribute("subscribedVideosPreview", videoService.getSubscribedVideos(user.getId())
+                .stream()
+                .limit(6)
+                .toList());
 
         return "you";
     }

--- a/src/main/java/edu/arizona/videoshare/dto/report/CreateReportRequest.java
+++ b/src/main/java/edu/arizona/videoshare/dto/report/CreateReportRequest.java
@@ -1,0 +1,16 @@
+package edu.arizona.videoshare.dto.report;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class CreateReportRequest {
+
+    @NotBlank
+    public String contentType;
+
+    @NotNull
+    public Long contentId;
+
+    @NotBlank
+    public String reason;
+}

--- a/src/main/java/edu/arizona/videoshare/dto/report/ReportResponse.java
+++ b/src/main/java/edu/arizona/videoshare/dto/report/ReportResponse.java
@@ -1,0 +1,29 @@
+package edu.arizona.videoshare.dto.report;
+
+import java.time.LocalDateTime;
+
+import edu.arizona.videoshare.model.entity.Report;
+import edu.arizona.videoshare.model.enums.ReportStatus;
+
+public class ReportResponse {
+
+    public Long id;
+    public String contentType;
+    public Long contentId;
+    public String reason;
+    public Long reportedByUserId;
+    public ReportStatus status;
+    public LocalDateTime createdAt;
+
+    public static ReportResponse of(Report report) {
+        ReportResponse r = new ReportResponse();
+        r.id = report.getId();
+        r.contentType = report.getContentType();
+        r.contentId = report.getContentId();
+        r.reason = report.getReason();
+        r.reportedByUserId = report.getReportedBy().getId();
+        r.status = report.getStatus();
+        r.createdAt = report.getCreatedAt();
+        return r;
+    }
+}

--- a/src/main/java/edu/arizona/videoshare/exception/GlobalExceptionHandler.java
+++ b/src/main/java/edu/arizona/videoshare/exception/GlobalExceptionHandler.java
@@ -121,6 +121,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     ResponseEntity<ApiError> handleGeneric(Exception ex) {
+        ex.printStackTrace();
         ApiError body = new ApiError(
                 HttpStatus.INTERNAL_SERVER_ERROR.value(),
                 "Internal Server Error",

--- a/src/main/java/edu/arizona/videoshare/model/entity/Report.java
+++ b/src/main/java/edu/arizona/videoshare/model/entity/Report.java
@@ -1,0 +1,50 @@
+package edu.arizona.videoshare.model.entity;
+
+import java.time.LocalDateTime;
+
+import edu.arizona.videoshare.model.enums.ReportStatus;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "reports")
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(nullable = false, length = 50)
+    private String contentType;
+
+    @Column(nullable = false)
+    private Long contentId;
+
+    @NotBlank
+    @Column(nullable = false, length = 500)
+    private String reason;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reported_by_user_id", nullable = false)
+    private User reportedBy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ReportStatus status = ReportStatus.OPEN;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public Report() {
+    }
+}

--- a/src/main/java/edu/arizona/videoshare/model/enums/ReportStatus.java
+++ b/src/main/java/edu/arizona/videoshare/model/enums/ReportStatus.java
@@ -1,0 +1,6 @@
+package edu.arizona.videoshare.model.enums;
+
+public enum ReportStatus {
+    OPEN,
+    RESOLVED
+}

--- a/src/main/java/edu/arizona/videoshare/repository/CommentRepository.java
+++ b/src/main/java/edu/arizona/videoshare/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package edu.arizona.videoshare.repository;
 
 import edu.arizona.videoshare.model.entity.Comment;
+import edu.arizona.videoshare.model.enums.CommentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,4 +11,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByVideoIdAndParentIsNullOrderByCreatedAtDesc(Long videoId);
 
     List<Comment> findByParent_IdOrderByCreatedAtAsc(Long parentId);
+
+    int countByParent_IdAndStatus(Long parentId, CommentStatus status);
 }

--- a/src/main/java/edu/arizona/videoshare/repository/ReportRepository.java
+++ b/src/main/java/edu/arizona/videoshare/repository/ReportRepository.java
@@ -1,0 +1,12 @@
+package edu.arizona.videoshare.repository;
+
+import edu.arizona.videoshare.model.entity.Report;
+import edu.arizona.videoshare.model.enums.ReportStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+    List<Report> findAllByOrderByCreatedAtDesc();
+    List<Report> findByStatusOrderByCreatedAtDesc(ReportStatus status);
+}

--- a/src/main/java/edu/arizona/videoshare/repository/SubscriptionRepository.java
+++ b/src/main/java/edu/arizona/videoshare/repository/SubscriptionRepository.java
@@ -20,6 +20,11 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
 
         List<Subscription> findByChannelIdAndStatus(Long channelId, Subscription.SubscriptionStatus status);
 
+        List<Subscription> findBySubscriberIdAndStatusOrderByCreatedAtDesc(
+                Long subscriberId,
+                Subscription.SubscriptionStatus status
+        );
+
         Optional<Subscription> findBySubscriberIdAndChannelIdAndStatus(
                         Long subscriberId,
                         Long channelId,

--- a/src/main/java/edu/arizona/videoshare/service/CommentService.java
+++ b/src/main/java/edu/arizona/videoshare/service/CommentService.java
@@ -180,11 +180,7 @@ public class CommentService {
                         .status(c.getStatus())
                         .likeCount(c.getLikeCount())
                         .dislikeCount(c.getDislikeCount())
-                        .replyCount(c.getReplies() != null
-                                ? (int) c.getReplies().stream()
-                                .filter(r -> r.getStatus() == CommentStatus.ACTIVE)
-                                .count()
-                                : 0)
+                        .replyCount(commentRepository.countByParent_IdAndStatus(c.getId(), CommentStatus.ACTIVE))
                         .createdAt(c.getCreatedAt())
                         .updatedAt(c.getUpdatedAt())
                         .build();

--- a/src/main/java/edu/arizona/videoshare/service/ReportService.java
+++ b/src/main/java/edu/arizona/videoshare/service/ReportService.java
@@ -1,0 +1,66 @@
+package edu.arizona.videoshare.service;
+
+import edu.arizona.videoshare.dto.report.CreateReportRequest;
+import edu.arizona.videoshare.exception.NotFoundException;
+import edu.arizona.videoshare.model.entity.Report;
+import edu.arizona.videoshare.model.entity.User;
+import edu.arizona.videoshare.model.entity.Video;
+import edu.arizona.videoshare.model.enums.ReportStatus;
+import edu.arizona.videoshare.repository.ReportRepository;
+import edu.arizona.videoshare.repository.UserRepository;
+import edu.arizona.videoshare.repository.VideoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+    private final VideoRepository videoRepository;
+
+    @Transactional
+    public Report createReport(Long reporterUserId, CreateReportRequest req) {
+        User reporter = userRepository.findById(reporterUserId)
+                .orElseThrow(() -> new NotFoundException("User not found: " + reporterUserId));
+
+        if (!"VIDEO".equalsIgnoreCase(req.contentType)) {
+            throw new IllegalArgumentException("Only VIDEO reports are supported right now.");
+        }
+
+        Video video = videoRepository.findById(req.contentId)
+                .orElseThrow(() -> new NotFoundException("Video not found: " + req.contentId));
+
+        Report report = new Report();
+        report.setContentType("VIDEO");
+        report.setContentId(video.getId());
+        report.setReason(req.reason.trim());
+        report.setReportedBy(reporter);
+        report.setStatus(ReportStatus.OPEN);
+
+        return reportRepository.save(report);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Report> getAllReports() {
+        return reportRepository.findAllByOrderByCreatedAtDesc();
+    }
+
+    @Transactional(readOnly = true)
+    public List<Report> getOpenReports() {
+        return reportRepository.findByStatusOrderByCreatedAtDesc(ReportStatus.OPEN);
+    }
+
+    @Transactional
+    public Report resolveReport(Long reportId) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new NotFoundException("Report not found: " + reportId));
+
+        report.setStatus(ReportStatus.RESOLVED);
+        return reportRepository.save(report);
+    }
+}

--- a/src/main/java/edu/arizona/videoshare/service/SubscriptionService.java
+++ b/src/main/java/edu/arizona/videoshare/service/SubscriptionService.java
@@ -91,6 +91,18 @@ public class SubscriptionService {
     }
 
     @Transactional(readOnly = true)
+    public List<Subscription> getActiveSubscriptionsForUser(Long userId) {
+        if (!userRepository.existsById(userId)) {
+            throw new NotFoundException("User not found: " + userId);
+        }
+
+        return subscriptionRepository.findBySubscriberIdAndStatusOrderByCreatedAtDesc(
+                userId,
+                Subscription.SubscriptionStatus.ACTIVE
+        );
+    }
+
+    @Transactional(readOnly = true)
     public List<Subscription> getUserSubscriptions(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() ->
                 new NotFoundException("User not found: " + userId));

--- a/src/main/java/edu/arizona/videoshare/service/UserService.java
+++ b/src/main/java/edu/arizona/videoshare/service/UserService.java
@@ -60,6 +60,12 @@ public class UserService {
                 .orElseThrow(() -> new NotFoundException("User not found: " + id));
     }
 
+    @Transactional(readOnly = true)
+    public User getByUsername(String username) {
+        return users.findByUsernameIgnoreCase(username)
+                .orElseThrow(() -> new NotFoundException("User not found: " + username));
+    }
+
     /**
      * UPDATE: Updates mutable profile fields for a user.
      */

--- a/src/main/java/edu/arizona/videoshare/service/UserService.java
+++ b/src/main/java/edu/arizona/videoshare/service/UserService.java
@@ -88,6 +88,24 @@ public class UserService {
         return users.save(user);
     }
 
+    @Transactional
+    public User suspend(Long id) {
+        User user = users.findById(id)
+                .orElseThrow(() -> new NotFoundException("User not found: " + id));
+
+        user.setStatus(UserStatus.SUSPENDED);
+        return users.save(user);
+    }
+
+    @Transactional
+    public User unlock(Long id) {
+        User user = users.findById(id)
+                .orElseThrow(() -> new NotFoundException("User not found: " + id));
+
+        user.setStatus(UserStatus.ACTIVE);
+        return users.save(user);
+    }
+
     /**
      * DELETE: Deletes a user by id.
      */

--- a/src/main/java/edu/arizona/videoshare/service/VerificationService.java
+++ b/src/main/java/edu/arizona/videoshare/service/VerificationService.java
@@ -33,13 +33,16 @@ public class VerificationService {
         verification.setUsed(false);
 
         tokens.save(verification);
-
-        emailService.sendVerificationEmail(
-                user.getEmail(),
-                user.getUsername(),
-                verification.getToken(),
-                verification.getCode()
-        );
+        try {
+            emailService.sendVerificationEmail(
+                    user.getEmail(),
+                    user.getUsername(),
+                    verification.getToken(),
+                    verification.getCode()
+            );
+        } catch (Exception e) {
+            System.out.println("Email failed (ignored in dev): " + e.getMessage());
+        }
     }
 
     @Transactional

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,8 +14,9 @@ spring.h2.console.path=/h2-console
 
 spring.thymeleaf.cache=false
 server.servlet.session.timeout=30m
-spring.servlet.multipart.max-file-size=50MB
-spring.servlet.multipart.max-request-size=50MB
+spring.servlet.multipart.max-file-size=75MB
+spring.servlet.multipart.max-request-size=75MB
+server.tomcat.max-swallow-size=-1
 
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587

--- a/src/main/resources/static/css/theme.css
+++ b/src/main/resources/static/css/theme.css
@@ -276,3 +276,130 @@ a:hover {
 .navbar button.navbar-icon-btn i {
     color: white !important;
 }
+
+.vs-video-card {
+    overflow: hidden;
+    background: #ffffff;
+}
+
+.vs-video-card .card-title,
+.vs-video-title {
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.25;
+    color: #1f2937;
+}
+
+.vs-video-meta {
+    color: #6c757d;
+    font-size: 0.875rem;
+}
+
+.vs-video-card-link {
+    display: block;
+}
+
+.vs-video-card-link:hover .vs-video-title,
+.vs-video-card-link:hover .card-title {
+    color: var(--vs-blue);
+}
+
+.vs-horizontal-video-card {
+    background: #ffffff;
+    border-radius: 1rem;
+    border: 1px solid rgba(94, 162, 255, 0.18);
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.06);
+    transition: transform var(--vs-transition-base), box-shadow var(--vs-transition-base);
+}
+
+.vs-horizontal-video-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 28px rgba(94, 162, 255, 0.16);
+}
+
+.vs-fixed-bottom-ad {
+    position: fixed;
+    left: 240px;
+    right: 0;
+    bottom: 0;
+    z-index: 1040;
+    display: flex;
+    justify-content: center;
+    pointer-events: none;
+    padding: 0.75rem 1rem;
+}
+
+.vs-fixed-bottom-ad-inner {
+    position: relative;
+    pointer-events: auto;
+    width: min(728px, 90vw);
+    background: rgba(255, 255, 255, 0.96);
+    border-radius: 1rem;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.18);
+    padding: 0.5rem;
+    text-align: center;
+}
+
+.vs-fixed-bottom-ad-label {
+    font-size: 0.75rem;
+    color: #6c757d;
+    margin-bottom: 0.25rem;
+}
+
+.vs-fixed-bottom-ad-img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 0.75rem;
+}
+
+.vs-fixed-bottom-ad {
+    position: fixed;
+    left: 240px;
+    right: 0;
+    bottom: 16px;
+    z-index: 2000;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    pointer-events: none;
+    padding: 0 1rem;
+}
+
+@media (max-width: 767.98px) {
+    .vs-fixed-bottom-ad {
+        left: 0;
+        padding: 0.5rem;
+    }
+}
+
+#sidebar.sidebar {
+    position: fixed !important;
+    top: 56px !important;
+    left: 0 !important;
+    height: calc(100vh - 56px) !important;
+    width: 240px !important;
+    overflow-y: auto !important;
+    z-index: 2050 !important;
+}
+
+.navbar {
+    position: sticky !important;
+    top: 0 !important;
+    z-index: 2100 !important;
+}
+
+main.flex-grow-1 {
+    margin-left: 240px;
+}
+
+@media (max-width: 767.98px) {
+    #sidebar.sidebar {
+        top: 56px !important;
+        width: 240px !important;
+        transform: translateX(-100%);
+    }
+
+    main.flex-grow-1 {
+        margin-left: 0;
+    }
+}

--- a/src/main/resources/templates/channel.html
+++ b/src/main/resources/templates/channel.html
@@ -30,7 +30,12 @@
                     <h1 class="h2 fw-bold mb-2" th:text="${channel.name}">Channel Name</h1>
 
                     <div class="text-muted mb-2">
-                        by <span th:text="${channel.user.displayName}">Owner Name</span>
+                        by 
+                        <a th:href="@{/users/{username}(username=${channel.user.username})}"
+                        class="text-decoration-none"
+                        th:text="${channel.user.displayName}">
+                            Owner Name
+                        </a>
                         <span class="mx-2">•</span>
                         <span id="subscriberCount" th:text="${channel.subscriberCount}">0</span> subscribers
                     </div>
@@ -152,7 +157,11 @@
 
             <div class="mb-3">
                 <div class="fw-semibold mb-1">Channel Owner</div>
-                <div class="text-muted" th:text="${channel.user.displayName}">Owner Name</div>
+                <a th:href="@{/users/{username}(username=${channel.user.username})}"
+                    class="text-decoration-none"
+                    th:text="${channel.user.displayName}">
+                    Owner Name
+                </a>
             </div>
 
             <div class="mb-3">

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -11,7 +11,7 @@
 
 <div id="sidebar"
      th:fragment="sidebar"
-     class="sidebar bg-dark text-white p-3"
+     class="sidebar bg-dark text-white p-3 d-flex flex-column"
      style="border-right:1px solid #2f2f2f;">
 
     <!-- Main navigation -->
@@ -36,11 +36,20 @@
         </li>
 
         <li class="nav-item mb-2">
-            <a th:href="@{/you#history}" class="nav-link text-white d-flex align-items-center gap-3 sidebar-link">
+            <a th:href="@{/history}" class="nav-link text-white d-flex align-items-center gap-3 sidebar-link">
             <span class="sidebar-icon">
                 <i class="bi bi-clock-history"></i>
             </span>
                 <span class="sidebar-text">Watch History</span>
+            </a>
+        </li>
+
+        <li class="nav-item mb-2" th:if="${session.loggedInUserId != null}">
+            <a th:href="@{/subscriptions/videos}" class="nav-link text-white d-flex align-items-center gap-3 sidebar-link">
+                <span class="sidebar-icon">
+                    <i class="bi bi-broadcast"></i>
+                </span>
+                <span class="sidebar-text">Subscribed Videos</span>
             </a>
         </li>
 
@@ -70,34 +79,50 @@
     <!-- Followed channels -->
     <div th:if="${session.loggedInUserId != null}">
         <hr class="border-secondary">
+
         <h6 class="text-uppercase text-white-50 small mb-3 sidebar-text">
             Following
         </h6>
 
-        <!-- Placeholder content to serve as example -->
-        <div class="d-flex flex-column gap-3">
+        <div th:if="${followedSubscriptions == null or #lists.isEmpty(followedSubscriptions)}"
+            class="text-white-50 small sidebar-text">
+            No followed channels yet.
+        </div>
 
-            <div class="d-flex align-items-center gap-3 sidebar-channel">
-                <div class="rounded-circle bg-secondary d-flex align-items-center justify-content-center sidebar-avatar">
-                    A
-                </div>
-                <span class="sidebar-text">Channel A</span>
-            </div>
+        <div th:if="${followedSubscriptions != null and !#lists.isEmpty(followedSubscriptions)}"
+            class="d-flex flex-column gap-2">
 
-            <div class="d-flex align-items-center gap-3 sidebar-channel">
-                <div class="rounded-circle bg-secondary d-flex align-items-center justify-content-center sidebar-avatar">
-                    B
-                </div>
-                <span class="sidebar-text">Channel B</span>
-            </div>
+            <a th:each="sub : ${followedSubscriptions}"
+            th:href="@{/{username}/channel/{channelName}(username=${sub.channel.user.username}, channelName=${sub.channel.name})}"
+            class="text-decoration-none text-white d-flex align-items-center gap-3 sidebar-channel rounded-3 px-2 py-2">
 
-            <div class="d-flex align-items-center gap-3 sidebar-channel">
-                <div class="rounded-circle bg-secondary d-flex align-items-center justify-content-center sidebar-avatar">
+                <img th:if="${sub.channel.avatarUrl != null and !#strings.isEmpty(sub.channel.avatarUrl)}"
+                    th:src="${sub.channel.avatarUrl}"
+                    alt="Channel avatar"
+                    class="rounded-circle sidebar-avatar"
+                    style="object-fit: cover;">
+
+                <div th:if="${sub.channel.avatarUrl == null or #strings.isEmpty(sub.channel.avatarUrl)}"
+                    class="rounded-circle bg-secondary d-flex align-items-center justify-content-center sidebar-avatar fw-semibold"
+                    th:text="${#strings.substring(sub.channel.name,0,1).toUpperCase()}">
                     C
                 </div>
-                <span class="sidebar-text">Channel C</span>
-            </div>
+
+                <span class="sidebar-text text-truncate"
+                    th:text="${sub.channel.name}">
+                    Channel Name
+                </span>
+            </a>
         </div>
+    </div>
+    <div class="mt-auto pt-3 border-top border-secondary" th:if="${session.loggedInUserId != null}">
+        <a th:href="@{/you}"
+        class="nav-link text-white d-flex align-items-center gap-3 sidebar-link">
+            <span class="sidebar-icon">
+                <i class="bi bi-person-circle"></i>
+            </span>
+            <span class="sidebar-text">Your Account</span>
+        </a>
     </div>
 </div>
 

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -74,10 +74,10 @@
                     </a>
                 `).join("");
 
-                //Add banner ads after every 6 videos
+                //Add banner ads after every 8 videos
                 const videoCards = videosGrid.querySelectorAll(':scope > a');
                 for (let i = 0; i < videoCards.length; i++) {
-                    if ((i + 1) % 6 === 0 && i + 1 < videoCards.length) {
+                    if ((i + 1) % 8 === 0 && i + 1 < videoCards.length) {
                         const adDiv = document.createElement('div');
                         adDiv.style.gridColumn = '1 / -1';
                         adDiv.innerHTML = `
@@ -113,5 +113,20 @@
             }
         });
     </script>
+    <div id="fixedBottomAd" class="vs-fixed-bottom-ad">
+        <div class="vs-fixed-bottom-ad-inner">
+            <div class="vs-fixed-bottom-ad-label">Advertisement</div>
+
+            <img src="https://picsum.photos/728/90"
+                alt="Advertisement"
+                class="vs-fixed-bottom-ad-img">
+
+            <button type="button"
+                    class="vs-fixed-bottom-ad-close"
+                    onclick="document.getElementById('fixedBottomAd').style.display='none'">
+                ×
+            </button>
+        </div>
+    </div>
 </th:block>
 </html>

--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -33,12 +33,20 @@
 
     <style>
         @keyframes vsFadeIn {
-            from { opacity: 0; transform: translateY(8px); }
-            to   { opacity: 1; transform: translateY(0); }
+            from { opacity: 0; }
+            to   { opacity: 1; }
         }
 
         main {
-            animation: vsFadeIn 0.35s ease-out both;
+            animation: vsFadeIn 0.25s ease-out;
+        }
+
+        .modal {
+            z-index: 1065;
+        }
+
+        .modal-backdrop {
+            z-index: 1055;
         }
     </style>
 
@@ -152,10 +160,11 @@
                     <div class="mb-3">
                         <label class="form-label small text-muted">Video File</label>
                         <input type="file"
-                               name="file"
-                               accept="video/mp4,video/webm,video/ogg,.mp4,.webm,.ogg"
-                               required
-                               class="form-control rounded-4 px-3">
+                            id="uploadVideoFile"
+                            name="file"
+                            accept="video/mp4,video/webm,video/ogg,.mp4,.webm,.ogg"
+                            required
+                            class="form-control rounded-4 px-3">
                         <div class="form-text">Upload an MP4, WebM, or OGG file up to 50 MB.</div>
                     </div>
 
@@ -291,6 +300,33 @@
             modal.show();
         }
     });
+</script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+    const uploadForm = document.querySelector('form[action="/videos/create"]');
+    const uploadFile = document.getElementById("uploadVideoFile");
+    const maxBytes = 50 * 1024 * 1024;
+
+    if (!uploadForm || !uploadFile) return;
+
+    uploadForm.addEventListener("submit", function (e) {
+        const file = uploadFile.files && uploadFile.files[0];
+
+        if (file && file.size > maxBytes) {
+            e.preventDefault();
+
+            const message = "Video file must be 50 MB or smaller.";
+
+            if (window.showToast) {
+                showToast(message, "error");
+            } else {
+                alert(message);
+            }
+
+            uploadFile.value = "";
+        }
+    });
+});
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/subscribed-videos.html
+++ b/src/main/resources/templates/subscribed-videos.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/base :: layout('Subscribed Videos | VideoShare', ~{::content}, true, true)}">
+
+<th:block th:fragment="content">
+    <div class="container py-5">
+
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
+            <div>
+                <h2 class="h4 mb-1">Subscribed Videos</h2>
+                <div class="text-muted small">Videos from channels you follow.</div>
+            </div>
+
+            <form method="get" th:action="@{/subscriptions/videos}">
+                <select class="form-select rounded-pill px-3"
+                        name="channelId"
+                        onchange="this.form.submit()">
+                    <option value="">All channels</option>
+
+                    <option th:each="sub : ${subscriptions}"
+                            th:value="${sub.channel.id}"
+                            th:selected="${selectedChannelId != null and selectedChannelId == sub.channel.id}"
+                            th:text="${sub.channel.name}">
+                        Channel
+                    </option>
+                </select>
+            </form>
+        </div>
+
+        <div th:if="${videosByChannel == null or videosByChannel.isEmpty()}" class="text-muted">
+            No subscribed videos found.
+        </div>
+
+        <div th:each="entry : ${videosByChannel}" class="mb-5">
+            <div class="d-flex align-items-center gap-3 mb-3">
+                <a th:href="@{/{username}/channel/{channelName}(username=${entry.key.user.username}, channelName=${entry.key.name})}"
+                   class="text-decoration-none text-dark d-flex align-items-center gap-3">
+                    <img th:if="${entry.key.avatarUrl != null and !#strings.isEmpty(entry.key.avatarUrl)}"
+                         th:src="${entry.key.avatarUrl}"
+                         class="rounded-circle border"
+                         style="width:48px; height:48px; object-fit:cover;"
+                         alt="Channel avatar">
+
+                    <div th:if="${entry.key.avatarUrl == null or #strings.isEmpty(entry.key.avatarUrl)}"
+                         class="rounded-circle bg-dark text-white d-flex align-items-center justify-content-center fw-bold"
+                         style="width:48px; height:48px;"
+                         th:text="${#strings.substring(entry.key.name,0,1).toUpperCase()}">
+                    </div>
+
+                    <div>
+                        <h3 class="h6 mb-0" th:text="${entry.key.name}">Channel</h3>
+                        <div class="text-muted small">
+                            <span th:text="${entry.key.subscriberCount}">0</span> subscribers
+                        </div>
+                    </div>
+                </a>
+            </div>
+
+            <div class="vs-video-grid">
+                <a th:each="video : ${entry.value}"
+                   th:href="@{/videos/{id}(id=${video.id})}"
+                   class="text-decoration-none text-dark vs-video-card-link">
+                    <div class="card h-100 border-0 shadow-sm rounded-4 vs-video-card">
+                        <div class="vs-video-thumb rounded-top-4 bg-dark text-white">
+                            <div>
+                                <i class="bi bi-play-btn fs-1"></i>
+                            </div>
+                        </div>
+
+                        <div class="card-body">
+                            <h5 class="card-title mb-2" th:text="${video.title}">Video Title</h5>
+                            <div class="text-muted small mb-1" th:text="${video.channel.name}">Channel</div>
+                            <div class="text-muted small"
+                                 th:if="${video.createdAt != null}"
+                                 th:text="'Uploaded ' + ${#temporals.format(video.createdAt, 'MMM d, yyyy')}">
+                                Uploaded date
+                            </div>
+                        </div>
+                    </div>
+                </a>
+            </div>
+        </div>
+
+    </div>
+</th:block>
+</html>

--- a/src/main/resources/templates/user-profile.html
+++ b/src/main/resources/templates/user-profile.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/base :: layout('VideoShare | @' + ${profileUser.username}, ~{::content}, true, true)}">
+
+<th:block th:fragment="content">
+    <div class="container py-5">
+
+        <div class="card border-0 shadow-sm rounded-4 mb-4">
+            <div class="card-body d-flex flex-column flex-md-row align-items-start align-items-md-center gap-4">
+                <img th:if="${profileUser.avatarUrl != null and !#strings.isEmpty(profileUser.avatarUrl)}"
+                     th:src="${profileUser.avatarUrl}"
+                     class="rounded-circle border"
+                     style="width:96px; height:96px; object-fit:cover;"
+                     alt="User avatar">
+
+                <div th:if="${profileUser.avatarUrl == null or #strings.isEmpty(profileUser.avatarUrl)}"
+                     class="rounded-circle bg-dark text-white d-flex align-items-center justify-content-center fw-bold"
+                     style="width:96px; height:96px; font-size:2.5rem;"
+                     th:text="${#strings.substring(profileUser.username,0,1).toUpperCase()}">
+                </div>
+
+                <div>
+                    <h1 class="h3 fw-bold mb-1" th:text="${profileUser.displayName}">Display Name</h1>
+                    <div class="text-muted mb-2">@<span th:text="${profileUser.username}">username</span></div>
+
+                    <p class="mb-0 text-secondary"
+                       th:if="${profileUser.bio != null and !#strings.isEmpty(profileUser.bio)}"
+                       th:text="${profileUser.bio}">
+                        Bio
+                    </p>
+
+                    <p class="mb-0 text-secondary"
+                       th:if="${profileUser.bio == null or #strings.isEmpty(profileUser.bio)}">
+                        No bio yet.
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <h2 class="h5 mb-0">Channels</h2>
+        </div>
+
+        <div th:if="${profileChannels == null or #lists.isEmpty(profileChannels)}" class="text-muted">
+            This user has no channels yet.
+        </div>
+
+        <div th:if="${profileChannels != null and !#lists.isEmpty(profileChannels)}" class="vs-video-grid">
+            <a th:each="channel : ${profileChannels}"
+               th:href="@{/{username}/channel/{channelName}(username=${channel.user.username}, channelName=${channel.name})}"
+               class="text-decoration-none text-dark">
+                <div class="card border-0 shadow-sm rounded-4 h-100">
+                    <div class="card-body d-flex align-items-center gap-3">
+                        <img th:if="${channel.avatarUrl != null and !#strings.isEmpty(channel.avatarUrl)}"
+                             th:src="${channel.avatarUrl}"
+                             alt="Channel avatar"
+                             class="rounded-circle"
+                             style="width:56px; height:56px; object-fit:cover;">
+
+                        <div th:if="${channel.avatarUrl == null or #strings.isEmpty(channel.avatarUrl)}"
+                             class="rounded-circle bg-dark text-white d-flex align-items-center justify-content-center fw-bold"
+                             style="width:56px; height:56px; font-size:20px;"
+                             th:text="${#strings.substring(channel.name,0,1).toUpperCase()}">
+                        </div>
+
+                        <div>
+                            <div class="fw-semibold" th:text="${channel.name}">Channel Name</div>
+                            <div class="text-muted small">
+                                <span th:text="${channel.subscriberCount}">0</span> subscribers
+                            </div>
+                            <div class="text-muted small"
+                                 th:text="${channel.description != null and !#strings.isEmpty(channel.description) ? channel.description : 'No description.'}">
+                                Description
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </a>
+        </div>
+
+    </div>
+</th:block>
+</html>

--- a/src/main/resources/templates/video.html
+++ b/src/main/resources/templates/video.html
@@ -11,13 +11,25 @@
                 <div class="bg-dark rounded-4 shadow-sm overflow-hidden d-flex align-items-center justify-content-center"
                      style="aspect-ratio: 16 / 9; width: 100%; max-height: 480px;">
 
-                    <div th:if="${ad != null}" id="adContainer" class="w-100 h-100">
+                    <div th:if="${ad != null}" id="adContainer" class="w-100 h-100 position-relative">
                         <video id="adPlayer"
                             class="w-100 h-100"
                             autoplay
                             style="object-fit: contain; background-color: #000;"
                             th:src="@{${ad.mediaUrl}}">
                         </video>
+
+                        <div id="adBadge"
+                            class="position-absolute top-0 start-0 m-3 px-3 py-2 rounded-pill bg-dark text-white small fw-semibold"
+                            style="z-index: 5; background: rgba(0,0,0,0.75) !important;">
+                            Advertisement
+                        </div>
+
+                        <div id="adCountdown"
+                            class="position-absolute top-0 end-0 m-3 px-3 py-2 rounded-pill bg-dark text-white small fw-semibold"
+                            style="z-index: 5; background: rgba(0,0,0,0.75) !important;">
+                            Ad
+                        </div>
                     </div>
 
                     <video id="videoPlayer"
@@ -76,7 +88,12 @@
                                 </div>
 
                                 <div class="text-muted small">
-                                    by <span th:text="${video.owner != null ? video.owner.displayName : video.channel.user.displayName}">Creator Name</span>
+                                    by
+                                    <a th:href="@{/users/{username}(username=${video.owner != null ? video.owner.username : video.channel.user.username})}"
+                                        class="text-decoration-none"
+                                        th:text="${video.owner != null ? video.owner.displayName : video.channel.user.displayName}">
+                                        Creator Name
+                                    </a>
                                 </div>
                             </div>
                         </div>
@@ -165,18 +182,52 @@
                 </div>
 
                 <div class="modal-body pt-2">
-                    <div th:if="${playlists == null or #lists.isEmpty(playlists)}" class="text-muted small">
-                        You do not have any playlists yet. Create one first.
+
+                    <div class="card border-0 bg-light rounded-4 mb-3">
+                        <div class="card-body">
+                            <h6 class="fw-semibold mb-3">Create New Playlist</h6>
+
+                            <input type="text"
+                                id="quickPlaylistName"
+                                class="form-control rounded-3 mb-2"
+                                placeholder="Playlist name">
+
+                            <input type="text"
+                                id="quickPlaylistDescription"
+                                class="form-control rounded-3 mb-2"
+                                placeholder="Description (optional)">
+
+                            <select id="quickPlaylistVisibility" class="form-select rounded-3 mb-3">
+                                <option value="PRIVATE">Private</option>
+                                <option value="PUBLIC">Public</option>
+                            </select>
+
+                            <button type="button"
+                                    id="quickCreatePlaylistBtn"
+                                    class="btn btn-dark rounded-pill px-4">
+                                Create and Add Video
+                            </button>
+
+                            <div id="quickPlaylistMessage" class="small mt-2"></div>
+                        </div>
                     </div>
 
-                    <div th:if="${playlists != null and !#lists.isEmpty(playlists)}" class="list-group">
-                        <button type="button"
-                                class="list-group-item list-group-item-action rounded-3 mb-2 add-to-playlist-btn"
-                                th:each="playlist : ${playlists}"
-                                th:attr="data-playlist-id=${playlist.id}"
-                                th:text="${playlist.name}">
-                            Playlist Name
-                        </button>
+                    <div th:if="${playlists == null or #lists.isEmpty(playlists)}" class="text-muted small">
+                        You do not have any playlists yet. Create one above.
+                    </div>
+
+                    <div th:if="${playlists != null and !#lists.isEmpty(playlists)}">
+                        <h6 class="fw-semibold mb-2">Add to Existing Playlist</h6>
+
+                        <div class="list-group" id="playlistList">
+                            <button type="button"
+                                    class="list-group-item list-group-item-action rounded-3 mb-2 add-to-playlist-btn"
+                                    th:each="playlist : ${playlists}"
+                                    th:attr="data-playlist-id=${playlist.id}"
+                                    th:text="${playlist.name}">
+                                Playlist Name
+                            </button>
+                        </div>
                     </div>
                 </div>
 
@@ -200,57 +251,83 @@
             const commentsList = document.getElementById("commentsList");
             const commentHeader = document.getElementById("commentHeader");
             const playlistAddMessage = document.getElementById("playlistAddMessage");
+            const quickCreatePlaylistBtn = document.getElementById("quickCreatePlaylistBtn");
+            const quickPlaylistMessage = document.getElementById("quickPlaylistMessage");
 
 
             const adContainer = document.getElementById("adContainer");
             const adPlayer = document.getElementById("adPlayer");
             const videoPlayer = document.getElementById("videoPlayer");
+            const adCountdown = document.getElementById("adCountdown");
+
+            function updateAdCountdown() {
+                if (!adPlayer || !adCountdown || !isFinite(adPlayer.duration)) {
+                    return;
+                }
+
+                const remaining = Math.max(0, Math.ceil(adPlayer.duration - adPlayer.currentTime));
+                adCountdown.textContent = `Ad ends in ${remaining}s`;
+            }
+
+            function showAd(adUrl, resumeVideoAfterAd) {
+                if (!adContainer || !adPlayer || !videoPlayer || !adUrl) {
+                    return;
+                }
+
+                videoPlayer.pause();
+                videoPlayer.style.display = "none";
+
+                adPlayer.src = adUrl;
+                adContainer.style.display = "block";
+                adPlayer.currentTime = 0;
+                adPlayer.play();
+
+                adPlayer.ontimeupdate = updateAdCountdown;
+                adPlayer.onloadedmetadata = updateAdCountdown;
+
+                adPlayer.onended = function () {
+                    adContainer.style.display = "none";
+                    videoPlayer.style.display = "block";
+
+                    if (resumeVideoAfterAd) {
+                        videoPlayer.play();
+                    }
+                };
+            }
 
             if (adContainer && adPlayer && videoPlayer) {
                 videoPlayer.style.display = "none";
 
+                adPlayer.ontimeupdate = updateAdCountdown;
+                adPlayer.onloadedmetadata = updateAdCountdown;
+
                 adPlayer.addEventListener("ended", function () {
-                    adContainer.style.display = "none"; 
-                    videoPlayer.style.display = "block"; 
+                    adContainer.style.display = "none";
+                    videoPlayer.style.display = "block";
                     videoPlayer.play();
                 });
             }
 
             const midRollUrl = /*[[${midRollAd != null ? midRollAd.mediaUrl : ''}]]*/ '';
+
             if (midRollUrl && videoPlayer) {
                 let midRollPlayed = false;
 
                 videoPlayer.addEventListener("timeupdate", function () {
                     const half = videoPlayer.duration / 2;
-                    if (!midRollPlayed && videoPlayer.currentTime >= half) {
+
+                    if (!midRollPlayed && videoPlayer.duration && videoPlayer.currentTime >= half) {
                         midRollPlayed = true;
-                        videoPlayer.pause();
-
-                        adPlayer.src = midRollUrl;
-                        adContainer.style.display = "block";
-                        videoPlayer.style.display = "none";
-                        adPlayer.play();
-
-                        adPlayer.onended = function () {
-                            adContainer.style.display = "none";
-                            videoPlayer.style.display = "block";
-                            videoPlayer.play();
-                        };
+                        showAd(midRollUrl, true);
                     }
                 });
             }
 
             const postRollUrl = /*[[${postRollAd != null ? postRollAd.mediaUrl : ''}]]*/ '';
+
             if (postRollUrl && videoPlayer) {
                 videoPlayer.addEventListener("ended", function () {
-                    adPlayer.src = postRollUrl;
-                    adContainer.style.display = "block";
-                    videoPlayer.style.display = "none";
-                    adPlayer.play();
-
-                    adPlayer.onended = function () {
-                        adContainer.style.display = "none";
-                    };
+                    showAd(postRollUrl, false);
                 });
             }
 
@@ -580,7 +657,10 @@ loadComments();
 
                         try {
                             const res = await fetch(`/api/videos/${videoId}/comments/${cid}/replies`);
-                            if (!res.ok) throw new Error();
+                            if (!res.ok) {
+                                const message = await readErrorMessage(res, "Could not load replies.");
+                                throw new Error(message);
+                            }
                             const replies = await res.json();
                             await Promise.all(replies.map(async (r) => {
                                 try {
@@ -633,10 +713,9 @@ loadComments();
                             container.classList.remove("d-none");
                             this.dataset.loaded = "true";
 
-                            // ADDED: attach event listeners for reply actions
-                            attachReplyEventListeners(cid);
+                            attachCommentEventListeners();
                         } catch (e) {
-                            container.innerHTML = '<p class="text-danger small">Could not load replies.</p>';
+                            container.innerHTML = `<p class="text-danger small">${e.message || 'Could not load replies.'}</p>`;
                             container.classList.remove("d-none");
                         }
                     });
@@ -809,6 +888,74 @@ loadComments();
                     }
                 });
             });
+
+            if (quickCreatePlaylistBtn) {
+                quickCreatePlaylistBtn.addEventListener("click", async function () {
+                    const nameInput = document.getElementById("quickPlaylistName");
+                    const descriptionInput = document.getElementById("quickPlaylistDescription");
+                    const visibilityInput = document.getElementById("quickPlaylistVisibility");
+
+                    const name = nameInput.value.trim();
+                    const description = descriptionInput.value.trim();
+                    const visibility = visibilityInput.value;
+
+                    if (quickPlaylistMessage) {
+                        quickPlaylistMessage.textContent = "";
+                        quickPlaylistMessage.className = "small mt-2";
+                    }
+
+                    if (!name) {
+                        if (quickPlaylistMessage) {
+                            quickPlaylistMessage.classList.add("text-danger");
+                            quickPlaylistMessage.textContent = "Playlist name is required.";
+                        }
+                        return;
+                    }
+
+                    try {
+                        const createRes = await fetch("/api/playlists", {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({
+                                userId: userId,
+                                name: name,
+                                description: description,
+                                visibility: visibility
+                            })
+                        });
+
+                        if (!createRes.ok) {
+                            const message = await readErrorMessage(createRes, "Could not create playlist.");
+                            throw new Error(message);
+                        }
+
+                        const playlist = await createRes.json();
+
+                        const addRes = await fetch(`/api/playlists/${playlist.id}/videos`, {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ videoId: videoId })
+                        });
+
+                        if (!addRes.ok) {
+                            const message = await readErrorMessage(addRes, "Playlist created, but video could not be added.");
+                            throw new Error(message);
+                        }
+
+                        showToast("Playlist created and video added!", "success");
+
+                        const modalEl = document.getElementById("addToPlaylistModal");
+                        const modal = bootstrap.Modal.getInstance(modalEl);
+                        if (modal) modal.hide();
+
+                    } catch (e) {
+                        if (quickPlaylistMessage) {
+                            quickPlaylistMessage.classList.add("text-danger");
+                            quickPlaylistMessage.textContent = e.message || "Could not create playlist.";
+                        }
+                    }
+                });
+            }
 
             async function readErrorMessage(res, fallbackMessage) {
     try {

--- a/src/main/resources/templates/watch-history.html
+++ b/src/main/resources/templates/watch-history.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/base :: layout('Watch History | VideoShare', ~{::content}, true, true)}">
+
+<th:block th:fragment="content">
+    <div class="container py-5">
+
+        <div class="mb-4">
+            <h2 class="h4 mb-1">Watch History</h2>
+            <div class="text-muted small">Videos you have watched recently.</div>
+        </div>
+
+        <div th:if="${history == null or #lists.isEmpty(history)}" class="text-muted">
+            No watch history yet.
+        </div>
+
+        <div th:if="${history != null and !#lists.isEmpty(history)}" class="vs-video-grid">
+            <a th:each="view : ${history}"
+               th:href="@{/videos/{id}(id=${view.video.id})}"
+               class="text-decoration-none text-dark vs-video-card-link">
+                <div class="card h-100 border-0 shadow-sm rounded-4 vs-video-card">
+                    <div class="vs-video-thumb rounded-top-4 bg-dark text-white">
+                        <div>
+                            <i class="bi bi-play-btn fs-1"></i>
+                        </div>
+                    </div>
+
+                    <div class="card-body">
+                        <h5 class="card-title mb-2" th:text="${view.video.title}">Video Title</h5>
+
+                        <div class="text-muted small mb-1"
+                             th:text="${view.video.channel != null ? view.video.channel.name : 'Unknown Channel'}">
+                            Channel
+                        </div>
+
+                        <div class="text-muted small mb-1">
+                            <span th:text="${view.watchDuration}">0</span>s watched
+                            <span th:if="${view.completed}"
+                                  class="badge bg-success-subtle text-success ms-1">
+                                Completed
+                            </span>
+                        </div>
+
+                        <div class="text-muted small"
+                             th:if="${view.watchedAt != null}"
+                             th:text="'Watched ' + ${#temporals.format(view.watchedAt, 'MMM d, yyyy h:mm a')}">
+                            Watched date
+                        </div>
+                    </div>
+                </div>
+            </a>
+        </div>
+
+    </div>
+</th:block>
+</html>

--- a/src/main/resources/templates/you.html
+++ b/src/main/resources/templates/you.html
@@ -246,97 +246,96 @@
         <!-- Subscribed Videos Section -->
         <section class="you-section">
             <div class="d-flex justify-content-between align-items-center you-section-header">
-                <h3 class="h5 mb-1">Subscribed Videos</h3>
-            </div>
-
-            <div class="row g-4">
-                <div class="col-12" th:if="${subscribedVideos == null or #lists.isEmpty(subscribedVideos)}">
-                    <p class="text-muted mb-0">No videos from subscribed channels yet.</p>
-                </div>
-
-                <div class="col-12 col-md-6 col-lg-4" th:each="video : ${subscribedVideos}">
-                    <a th:href="@{/videos/{id}(id=${video.id})}" class="text-decoration-none text-dark">
-                        <div class="card h-100 border-0 bg-white shadow-sm rounded-4 p-3">
-                            <div class="d-flex align-items-start gap-3">
-                                <div class="flex-shrink-0">
-                                    <div class="rounded-3 bg-light d-flex align-items-center justify-content-center"
-                                         style="width:80px; height:56px;">
-                                        <i class="bi bi-play-circle text-muted" style="font-size:1.5rem;"></i>
-                                    </div>
-                                </div>
-
-                                <div class="flex-grow-1">
-                                    <div class="fw-semibold text-truncate" th:text="${video.title}">Video Title</div>
-
-                                    <div class="text-muted small"
-                                         th:text="${video.channel != null ? video.channel.name : 'Unknown Channel'}">
-                                        Channel Name
-                                    </div>
-
-                                    <div class="text-muted small"
-                                         th:if="${video.createdAt != null}"
-                                         th:text="'Uploaded ' + ${#temporals.format(video.createdAt, 'MMM d, yyyy')}">
-                                        Uploaded date
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                <div>
+                    <h3 class="h5 mb-1">Subscribed Videos</h3>
+                    <a th:href="@{/subscriptions/videos}" class="text-decoration-none small">
+                        View all subscribed videos
                     </a>
                 </div>
+            </div>
+
+            <div th:if="${subscribedVideosPreview == null or #lists.isEmpty(subscribedVideosPreview)}" class="text-muted">
+                No videos from subscribed channels yet.
+            </div>
+
+            <div th:if="${subscribedVideosPreview != null and !#lists.isEmpty(subscribedVideosPreview)}" class="vs-video-grid">
+                <a th:each="video : ${subscribedVideosPreview}"
+                th:href="@{/videos/{id}(id=${video.id})}"
+                class="text-decoration-none text-dark vs-video-card-link">
+                    <div class="card h-100 border-0 shadow-sm rounded-4 vs-video-card">
+                        <div class="vs-video-thumb rounded-top-4 bg-dark text-white">
+                            <div>
+                                <i class="bi bi-play-btn fs-1"></i>
+                            </div>
+                        </div>
+
+                        <div class="card-body">
+                            <h5 class="card-title mb-2" th:text="${video.title}">Video Title</h5>
+                            <div class="text-muted small mb-1"
+                                th:text="${video.channel != null ? video.channel.name : 'Unknown Channel'}">
+                                Channel
+                            </div>
+                            <div class="text-muted small"
+                                th:if="${video.createdAt != null}"
+                                th:text="'Uploaded ' + ${#temporals.format(video.createdAt, 'MMM d, yyyy')}">
+                                Uploaded date
+                            </div>
+                        </div>
+                    </div>
+                </a>
             </div>
         </section>
 
         <!-- History Section -->
         <section class="you-section" id="history">
             <div class="d-flex justify-content-between align-items-center you-section-header">
-                <h3 class="h5 mb-1">History</h3>
-            </div>
-
-            <div class="row g-4">
-                <div class="col-12" th:if="${history == null or #lists.isEmpty(history)}">
-                    <p class="text-muted mb-0">No history yet.</p>
-                </div>
-
-                <div class="col-12 col-md-6 col-lg-4" th:each="view : ${history}">
-                    <a th:href="@{/videos/{id}(id=${view.video.id})}" class="text-decoration-none text-dark">
-                        <div class="card h-100 border-0 bg-white shadow-sm rounded-4 p-3">
-                            <div class="d-flex align-items-start gap-3">
-                                <div class="flex-shrink-0">
-                                    <div class="rounded-3 bg-light d-flex align-items-center justify-content-center"
-                                         style="width:80px; height:56px;">
-                                        <i class="bi bi-play-circle text-muted" style="font-size:1.5rem;"></i>
-                                    </div>
-                                </div>
-
-                                <div class="flex-grow-1">
-                                    <div class="fw-semibold text-truncate"
-                                         th:text="${view.video.title}">
-                                        Video Title
-                                    </div>
-
-                                    <div class="text-muted small"
-                                         th:text="${view.video.channel != null ? view.video.channel.name : ''}">
-                                        Channel
-                                    </div>
-
-                                    <div class="text-muted small">
-                                        <span th:text="${view.watchDuration}">0</span>s watched
-                                        <span th:if="${view.completed}"
-                                              class="badge bg-success-subtle text-success ms-1">
-                                            Completed
-                                        </span>
-                                    </div>
-
-                                    <div class="text-muted small"
-                                         th:if="${view.watchedAt != null}"
-                                         th:text="|Watched ${#temporals.format(view.watchedAt, 'MMM d, yyyy h:mm a')}|">
-                                        Watched date
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                <div>
+                    <h3 class="h5 mb-1">History</h3>
+                    <a th:href="@{/history}" class="text-decoration-none small">
+                        View all watch history
                     </a>
                 </div>
+            </div>
+
+            <div th:if="${historyPreview == null or #lists.isEmpty(historyPreview)}" class="text-muted">
+                No history yet.
+            </div>
+
+            <div th:if="${historyPreview != null and !#lists.isEmpty(historyPreview)}" class="vs-video-grid">
+                <a th:each="view : ${historyPreview}"
+                th:href="@{/videos/{id}(id=${view.video.id})}"
+                class="text-decoration-none text-dark vs-video-card-link">
+                    <div class="card h-100 border-0 shadow-sm rounded-4 vs-video-card">
+                        <div class="vs-video-thumb rounded-top-4 bg-dark text-white">
+                            <div>
+                                <i class="bi bi-play-btn fs-1"></i>
+                            </div>
+                        </div>
+
+                        <div class="card-body">
+                            <h5 class="card-title mb-2" th:text="${view.video.title}">Video Title</h5>
+
+                            <div class="text-muted small mb-1"
+                                th:text="${view.video.channel != null ? view.video.channel.name : 'Unknown Channel'}">
+                                Channel
+                            </div>
+
+                            <div class="text-muted small mb-1">
+                                <span th:text="${view.watchDuration}">0</span>s watched
+                                <span th:if="${view.completed}"
+                                    class="badge bg-success-subtle text-success ms-1">
+                                    Completed
+                                </span>
+                            </div>
+
+                            <div class="text-muted small"
+                                th:if="${view.watchedAt != null}"
+                                th:text="'Watched ' + ${#temporals.format(view.watchedAt, 'MMM d, yyyy h:mm a')}">
+                                Watched date
+                            </div>
+                        </div>
+                    </div>
+                </a>
             </div>
         </section>
 


### PR DESCRIPTION
COMMIT #1:
## Summary
Implemented admin moderation support and reported-content workflow.

## Changes
- Added admin role session support through `loggedInRole`
- Protected admin-only user management endpoints
- Added user suspend and unlock actions
- Restricted user delete to admins
- Restricted video deletion to admins
- Allowed admins to remove/update channels
- Added reported content system:
  - `Report` entity
  - `ReportStatus` enum
  - `ReportRepository`
  - `ReportService`
  - `ReportController`
  - report request/response DTOs
- Added endpoints for:
  - creating a report
  - viewing all reports
  - viewing open reports
  - resolving reports

## Endpoints Added/Updated
- `GET /api/users` — admin only
- `PUT /api/users/{id}/suspend` — admin only
- `PUT /api/users/{id}/unlock` — admin only
- `DELETE /api/users/{id}` — admin only
- `DELETE /api/videos/{id}` — admin only
- `POST /api/reports` — logged-in users
- `GET /api/reports` — admin only
- `GET /api/reports/open` — admin only
- `PUT /api/reports/{id}/resolve` — admin only

## Testing
Tested with Postman:
- Registered/logged in users
- Updated admin user role in H2 database
- Verified admin-only endpoints reject unauthenticated users
- Verified normal user can create a report
- Verified admin can view all reports
- Verified admin can view open reports
- Verified admin can resolve reports
- Verified resolved reports no longer appear in open reports
- Verified admin can delete reported video content


COMMIT #2:
## Summary
This PR adds several user-facing library/navigation improvements and fixes multiple UI issues discovered after the previous PR.

## Issues Addressed
- #216 Create dedicated subscribed videos page with channel filtering capability
- #215 Apply consistent video layout styling to watch history and playlist pages
- #214 Create dedicated watch history page
- #213 Add "create new playlist" option directly in the Add to Playlist modal
- #212 Create clickable user profiles that display all of the user's channels

## Additional Fixes Included
- Fixed Create Channel modal becoming visible but unclickable
- Fixed Add to Playlist modal becoming visible but unclickable
- Made sidebar Following section dynamic instead of hardcoded placeholders
- Added subscribed channels to sidebar based on active subscriptions
- Added sticky top navbar
- Made sidebar fixed so it does not scroll with the page
- Added bottom account link to sidebar
- Reworked homepage ad placement into a fixed bottom ad
- Added close button for fixed bottom ad
- Added frontend validation for videos larger than 50 MB
- Increased multipart backend limit so oversized uploads can show a user-friendly error
- Fixed comment replies failing due to missing reply listener function
- Improved ad playback UI with Advertisement label and countdown timer

## New Pages / Routes
- `/subscriptions/videos`
  - Dedicated subscribed videos page
  - Supports filtering by followed channel
  - Groups subscribed videos by channel

- `/history`
  - Dedicated watch history page
  - Displays watched videos with duration/completion metadata

- `/users/{username}`
  - Public user profile page
  - Shows user profile information and all channels owned by that user

## UI / Template Changes
- Updated `/you` page to show previews for subscribed videos and watch history instead of full sections
- Added "View all" links from `/you` to dedicated library pages
- Updated video cards to use consistent shared styling
- Made creator/user names clickable where appropriate
- Added create-playlist flow directly inside Add to Playlist modal
- Updated sidebar navigation links for Watch History and Subscribed Videos
- Replaced placeholder Following entries with real subscribed channels

## Backend Changes
- Added active subscription lookup for dynamic sidebar and channel filtering
- Added user lookup by username for public profiles
- Added controller routes for subscribed videos, watch history, and public user profiles
- Added safer reply loading behavior for comments
- Added oversized upload handling improvements

## Testing
Tested manually:
- Create Channel modal opens and accepts input
- Add to Playlist modal opens and accepts input
- Creating a playlist from the video page works
- Adding a video to an existing playlist works
- Watch history page loads
- Subscribed videos page loads
- Channel filter works on subscribed videos page
- Sidebar Following section updates after subscribing to channels
- Top navbar stays sticky
- Sidebar remains fixed while scrolling
- Fixed bottom ad remains visible while scrolling
- Oversized video upload shows a user-facing error instead of a network error
- Comment replies load correctly
- Video ads show an Advertisement label and countdown